### PR TITLE
docs: spec review — sources, session lease, transports, scene-owned rendering

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,7 +42,7 @@
          │  même protocole, même registre
     ┌────┴─────────┐
     │ Simulateur   │
-    │ (navigateur) │
+    │ (page Nuxt)  │
     └──────────────┘
 ```
 
@@ -50,8 +50,9 @@
 
 | Composant | Rôle | Ne fait pas |
 |-----------|------|-------------|
-| **Nuxt** | Dashboard : appairage, édition de scènes, supervision | Ne parle jamais à un renderer |
-| **AdonisJS** | Plan de contrôle : authentification, registre, persistance, assignation | N'est jamais dans le chemin 30 FPS |
+| **Nuxt** | Dashboard : appairage, édition de scènes, supervision. Sert aussi la page du simulateur | En tant que dashboard, ne parle jamais à un renderer |
+| **Simulateur** | Page du dashboard qui se substitue au matériel et parle le protocole device ([SIMULATOR.md](SIMULATOR.md)) | Ne partage aucun code avec le renderer : ce n'est pas une prévisualisation |
+| **AdonisJS** | Plan de contrôle : authentification, registre, persistance, assignation | N'est jamais dans le chemin de rendu |
 | **PostgreSQL** | Source de vérité unique | N'est lu que par Adonis |
 | **Renderer** | Plan de données : calcule les frames, tient les connexions device | N'accède jamais à la base |
 | **Device** | Reçoit, décode, écrit sur la dalle | Aucune logique d'affichage |
@@ -64,7 +65,7 @@ et sensible à la milliseconde. Ils n'ont ni le même transport, ni le même for
 
 | # | Chemin | Transport | Format | Cadence | Spécification |
 |---|--------|-----------|--------|---------|---------------|
-| 1 | Renderer → Device | WebSocket | **Binaire** | ~30 FPS | [PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md) |
+| 1 | Renderer → Device | WebSocket | **Binaire** | 1 à 60 FPS, 30 par défaut | [PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md) |
 | 2 | Renderer ↔ Adonis | WSS sortant | JSON versionné | Événementiel | [PROTOCOL-CONTROL.md](PROTOCOL-CONTROL.md) |
 | 3 | Device → Adonis | HTTP | JSON | Une fois au boot | [PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md#bootstrap) |
 
@@ -87,9 +88,9 @@ Un renderer **n'expose aucun port à la plateforme**. Le seul port qu'il ouvre s
 ```
 1. Le device s'allume. Il connaît l'adresse de la plateforme et son token (gravés au flash).
 2. GET /api/v1/device/bootstrap        (authentifié par le token device)
-       ──▶ { renderer_url, panel: { width, height, chain }, scene_version }
+       ──▶ { renderer_urls, panel: { width, height, chain }, scene_version }
 3. Il met la réponse en cache local.
-4. Il ouvre un WebSocket vers renderer_url.
+4. Il choisit une URL selon son transport (wss d'abord) et ouvre un WebSocket.
 5. Il envoie son token en premier message binaire.
 6. Le renderer valide, répond CONFIG, puis pousse une FULL_FRAME et commence à streamer.
 ```
@@ -133,9 +134,10 @@ ajoutées. Voir [SELF-HOSTING.md](SELF-HOSTING.md).
 
 Le renderer met en cache les empreintes de tokens device pour rester autonome
 ([ADR-0008](adr/0008-renderer-autonome.md)). Une révocation n'est donc **pas instantanée**. Trois mécanismes la
-bornent : un événement de révocation poussé sur le canal de contrôle, une durée de validité des entrées en
-cache, et un comportement défini quand le renderer est hors ligne. Voir
-[PROTOCOL-CONTROL.md](PROTOCOL-CONTROL.md).
+bornent : un événement de révocation poussé sur le canal de contrôle, un **bail de session** par device qui
+expire faute de contact avec la plateforme ([ADR-0015](adr/0015-bail-de-session-device.md)), et un comportement
+défini quand le renderer est hors ligne. La fenêtre d'exposition est donc finie, et sa durée se règle par dalle.
+Voir [PROTOCOL-CONTROL.md](PROTOCOL-CONTROL.md).
 
 ## Resynchronisation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,8 +38,8 @@
 │ S3 + HUB75     │          │ S3 + HUB75         │
 └────────────────┘          └────────────────────┘
          ▲
-         │  Le simulateur se substitue au matériel,
-         │  même protocole, même registre
+         │  Le simulateur est un device du registre,
+         │  même protocole, sans matériel
     ┌────┴─────────┐
     │ Simulateur   │
     │ (page Nuxt)  │
@@ -51,7 +51,7 @@
 | Composant | Rôle | Ne fait pas |
 |-----------|------|-------------|
 | **Nuxt** | Dashboard : appairage, édition de scènes, supervision. Sert aussi la page du simulateur | En tant que dashboard, ne parle jamais à un renderer |
-| **Simulateur** | Page du dashboard qui se substitue au matériel et parle le protocole device ([SIMULATOR.md](SIMULATOR.md)) | Ne partage aucun code avec le renderer : ce n'est pas une prévisualisation |
+| **Simulateur** | Page du dashboard qui tient le rôle du matériel, sur un device déclaré `kind = simulator`, et parle le protocole device ([SIMULATOR.md](SIMULATOR.md)) | Ne partage aucun code avec le renderer, et n'emprunte l'identité d'aucune dalle |
 | **AdonisJS** | Plan de contrôle : authentification, registre, persistance, assignation | N'est jamais dans le chemin de rendu |
 | **PostgreSQL** | Source de vérité unique | N'est lu que par Adonis |
 | **Renderer** | Plan de données : calcule les frames, tient les connexions device | N'accède jamais à la base |

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -54,7 +54,7 @@ Un appareil qui affiche : matériel ou simulateur.
 | `tokenHash` | string | Empreinte du secret du credential |
 | `tokenPrefix` | string | Préfixe en clair, unique et indexé |
 | `panelType` | enum | `hub75` — seule valeur supportée ([ADR-0005](adr/0005-hub75-dabord.md)) |
-| `isSimulator` | boolean | Distingue un simulateur dans l'interface |
+| `kind` | enum | `hardware` \| `simulator`. Nature du device, choisie à la création et non modifiable ensuite ([ADR-0020](adr/0020-simulateur-device-declare.md)) |
 | `width` / `height` | integer | Géométrie totale en pixels |
 | `chainLength` | integer | Nombre de dalles chaînées |
 | `brightness` | integer | Luminosité de la dalle, 0 à 255. Défaut 128 |
@@ -80,6 +80,12 @@ Un appareil qui affiche : matériel ou simulateur.
   d'exposition de ce device infinie : c'est un choix légitime pour une dalle sans donnée sensible, jamais un
   défaut.
 - `width` et `height` sont strictement positifs et multiples de la géométrie d'une dalle.
+- `kind` se choisit à la création et ne change plus. Un device simulateur n'est pas une dalle qu'un onglet
+  remplace : c'est un device à part entière, avec son token et sa géométrie, et le simulateur ne propose que les
+  devices `kind = simulator` ([ADR-0020](adr/0020-simulateur-device-declare.md)).
+- `kind` **ne voyage pas sur le plan de contrôle** : le renderer l'ignore, et le doit. La règle est tenue par
+  l'API et le dashboard ; ce n'est pas une frontière d'authentification, rien dans le protocole device ne
+  distinguant un navigateur d'un firmware.
 - `firmwareVersion`, `protocolVersion`, `status`, `lastSeenAt` et `ipAddress` sont **observés**, jamais saisis.
 - Un device appartient à un utilisateur ; son renderer peut appartenir à un autre utilisateur uniquement s'il
   s'agit du renderer de la plateforme.
@@ -181,6 +187,7 @@ Le découpage :
 | `config`, `userId` | `scenes`, avec un nom dérivé de celui de la matrice |
 | `width`, `height` | recopiés aussi dans `scenes` : la scène migrée a la géométrie de la matrice, donc `k = 1` |
 | — | aucune cadence à migrer : `scenes.targetFps` prend son défaut de 30, `devices.maxFps` reste `null` |
+| — | `devices.kind` vaut `hardware` : une matrice existante décrit du matériel |
 | — | `devices.sceneId` pointe vers la scène créée |
 | — | `devices.rendererId` pointe vers le renderer par défaut |
 | — | `devices.tokenHash` doit être régénéré : aucun token n'existe dans le schéma actuel |

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -161,6 +161,10 @@ mxd_71ce04ba82df_4d2f…   device
   ce qui le rattache à une ligne, puisqu'une empreinte salée ne se recherche pas.
 - l'étiquette de tête porte la portée : un token de device présenté sur le canal renderer est rejeté sans même
   vérifier le secret.
+- un credential se **remplace**, il ne se relit pas. La rotation crée un nouveau secret — affiché une fois lui
+  aussi — et invalide immédiatement le précédent. C'est la réponse à une fuite, et le moyen par lequel le
+  simulateur obtient un token utilisable à l'ouverture
+  ([ADR-0021](adr/0021-credential-du-simulateur-par-rotation.md)).
 
 **Une exception : le renderer de la plateforme.** Il n'a pas de propriétaire, donc personne ne peut l'appairer
 depuis l'interface. Son credential est déclaré par le déploiement dans `PLATFORM_RENDERER_TOKEN` et appliqué au

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -49,7 +49,7 @@ Un appareil qui affiche : matériel ou simulateur.
 | `id` | uuid | Clé primaire |
 | `userId` | uuid | Propriétaire |
 | `rendererId` | uuid | Renderer qui sert ce device |
-| `sceneId` | uuid \| null | Scène assignée. `null` = écran noir |
+| `sceneId` | uuid \| null | Scène assignée. `null` = écran noir. La géométrie du device doit être un multiple entier de celle de la scène ([ADR-0018](adr/0018-geometrie-native-de-la-scene.md)) |
 | `name` | string | Nom lisible, 3 à 100 caractères |
 | `tokenHash` | string | Empreinte du secret du credential |
 | `tokenPrefix` | string | Préfixe en clair, unique et indexé |
@@ -58,7 +58,7 @@ Un appareil qui affiche : matériel ou simulateur.
 | `width` / `height` | integer | Géométrie totale en pixels |
 | `chainLength` | integer | Nombre de dalles chaînées |
 | `brightness` | integer | Luminosité de la dalle, 0 à 255. Défaut 128 |
-| `targetFps` | integer | Cadence visée, 1 à 60. Défaut 30 ([ADR-0001](adr/0001-streaming-de-frames.md)) |
+| `maxFps` | integer \| null | Plafond d'émission, 1 à 60. `null` = aucun plafond, valeur par défaut ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) |
 | `offlineGrace` | integer \| null | Secondes pendant lesquelles le renderer peut servir ce device sans contact avec la plateforme. `null` = illimité. Défaut 604 800, soit 7 jours ([ADR-0015](adr/0015-bail-de-session-device.md)) |
 | `firmwareVersion` | string \| null | Déclarée par le device |
 | `protocolVersion` | integer \| null | Déclarée par le device |
@@ -71,8 +71,11 @@ Un appareil qui affiche : matériel ou simulateur.
 
 - `width × height ≤ 65 536`. La limite dérive de l'index de pixel sur 16 bits du protocole
   ([PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md)), soit 256×256 au maximum.
-- `1 ≤ targetFps ≤ 60`. Bornée à l'écriture : la valeur part telle quelle vers le renderer puis vers le device,
-  et rien en aval ne la revalide.
+- `1 ≤ maxFps ≤ 60` quand il n'est pas `null`. Borné à l'écriture, comme la cadence de la scène : la valeur part
+  telle quelle vers le renderer puis vers le device, et rien en aval ne la revalide.
+- La cadence n'appartient pas au device : il n'en pose qu'un plafond. Un device plafonné reçoit une frame sur
+  `n = ⌈scene.targetFps / maxFps⌉`, donc une cadence effective qui est un **sous-multiple exact** de celle de la
+  scène ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)).
 - `offlineGrace` est le curseur entre révocation rapide et autonomie longue. Le mettre à `null` rend la fenêtre
   d'exposition de ce device infinie : c'est un choix légitime pour une dalle sans donnée sensible, jamais un
   défaut.
@@ -90,9 +93,24 @@ Un contenu à afficher.
 | `id` | uuid | Clé primaire |
 | `userId` | uuid | Propriétaire |
 | `name` | string | Nom lisible, 3 à 100 caractères |
+| `width` / `height` | integer | Géométrie native, celle pour laquelle la scène est écrite ([ADR-0018](adr/0018-geometrie-native-de-la-scene.md)) |
+| `targetFps` | integer | Cadence à laquelle la scène est évaluée, 1 à 60. Défaut 30 ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) |
 | `config` | jsonb | Configuration versionnée et validée |
 | `version` | integer | Incrémenté à chaque modification, sert au diff du plan de contrôle |
 | `createdAt` / `updatedAt` | timestamptz | |
+
+**Règles**
+
+- `width × height ≤ 65 536`, comme pour un device : une scène plus grande que le maximum du protocole ne
+  pourrait être affichée nulle part.
+- `1 ≤ targetFps ≤ 60`. C'est la scène qui décide de sa cadence : une horloge n'a rien à recalculer trente fois
+  par seconde, un texte défilant si.
+- Une scène ne peut être assignée qu'à un device dont la géométrie est un **multiple entier de la sienne, de
+  même facteur sur les deux axes** — `device.width = k × scene.width` et `device.height = k × scene.height`,
+  `k` entier ≥ 1. Le renderer réplique alors chaque pixel en un bloc `k×k`
+  ([ADR-0018](adr/0018-geometrie-native-de-la-scene.md)).
+- Changer la géométrie d'un device ou d'une scène doit être refusé, ou désassigner explicitement : une paire
+  incompatible ne reste jamais en base.
 
 ### Configuration de scène
 
@@ -161,6 +179,8 @@ Le découpage :
 |------------------|-------------|
 | `id`, `name`, `width`, `height`, `userId` | `devices` |
 | `config`, `userId` | `scenes`, avec un nom dérivé de celui de la matrice |
+| `width`, `height` | recopiés aussi dans `scenes` : la scène migrée a la géométrie de la matrice, donc `k = 1` |
+| — | aucune cadence à migrer : `scenes.targetFps` prend son défaut de 30, `devices.maxFps` reste `null` |
 | — | `devices.sceneId` pointe vers la scène créée |
 | — | `devices.rendererId` pointe vers le renderer par défaut |
 | — | `devices.tokenHash` doit être régénéré : aucun token n'existe dans le schéma actuel |

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -79,7 +79,7 @@ Un appareil qui affiche : matériel ou simulateur.
 - `offlineGrace` est le curseur entre révocation rapide et autonomie longue. Le mettre à `null` rend la fenêtre
   d'exposition de ce device infinie : c'est un choix légitime pour une dalle sans donnée sensible, jamais un
   défaut.
-- `width` et `height` sont strictement positifs et multiples de la géométrie d'une dalle.
+- `width` et `height` sont strictement positifs.
 - `kind` se choisit à la création et ne change plus. Un device simulateur n'est pas une dalle qu'un onglet
   remplace : c'est un device à part entière, avec son token et sa géométrie, et le simulateur ne propose que les
   devices `kind = simulator` ([ADR-0020](adr/0020-simulateur-device-declare.md)).

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -28,7 +28,7 @@ Un moteur de rendu déclaré auprès de la plateforme.
 | `isDefault` | boolean | Renderer assigné par défaut aux nouveaux devices |
 | `version` | string \| null | Version annoncée à la connexion. `null` tant qu'il ne s'est pas connecté |
 | `capabilities` | jsonb \| null | Primitives que ce renderer sait rendre. `null` tant qu'il ne s'est pas connecté |
-| `endpoint` | string \| null | Adresse annoncée, transmise aux devices au bootstrap |
+| `endpoints` | jsonb \| null | Adresses annoncées, transmises telles quelles aux devices au bootstrap. Liste : `wss://`, `ws://`, ou les deux ([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)) |
 | `status` | enum | `online` \| `offline` |
 | `lastSeenAt` | timestamptz \| null | Dernière activité sur le canal de contrôle |
 | `createdAt` / `updatedAt` | timestamptz | |
@@ -36,7 +36,7 @@ Un moteur de rendu déclaré auprès de la plateforme.
 **Règles**
 
 - Exactement un renderer porte `isDefault = true` et `ownerId = null`.
-- `version`, `capabilities` et `endpoint` sont **déclarés par le renderer** à sa connexion. Ce sont des données
+- `version`, `capabilities` et `endpoints` sont **déclarés par le renderer** à sa connexion. Ce sont des données
   non fiables : Adonis les valide et les borne avant de les persister.
 - `status` et `lastSeenAt` sont dérivés de l'état de la connexion de contrôle, jamais renseignés par une requête.
 
@@ -57,6 +57,9 @@ Un appareil qui affiche : matériel ou simulateur.
 | `isSimulator` | boolean | Distingue un simulateur dans l'interface |
 | `width` / `height` | integer | Géométrie totale en pixels |
 | `chainLength` | integer | Nombre de dalles chaînées |
+| `brightness` | integer | Luminosité de la dalle, 0 à 255. Défaut 128 |
+| `targetFps` | integer | Cadence visée, 1 à 60. Défaut 30 ([ADR-0001](adr/0001-streaming-de-frames.md)) |
+| `offlineGrace` | integer \| null | Secondes pendant lesquelles le renderer peut servir ce device sans contact avec la plateforme. `null` = illimité. Défaut 604 800, soit 7 jours ([ADR-0015](adr/0015-bail-de-session-device.md)) |
 | `firmwareVersion` | string \| null | Déclarée par le device |
 | `protocolVersion` | integer \| null | Déclarée par le device |
 | `status` | enum | `online` \| `offline` \| `error` |
@@ -68,6 +71,11 @@ Un appareil qui affiche : matériel ou simulateur.
 
 - `width × height ≤ 65 536`. La limite dérive de l'index de pixel sur 16 bits du protocole
   ([PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md)), soit 256×256 au maximum.
+- `1 ≤ targetFps ≤ 60`. Bornée à l'écriture : la valeur part telle quelle vers le renderer puis vers le device,
+  et rien en aval ne la revalide.
+- `offlineGrace` est le curseur entre révocation rapide et autonomie longue. Le mettre à `null` rend la fenêtre
+  d'exposition de ce device infinie : c'est un choix légitime pour une dalle sans donnée sensible, jamais un
+  défaut.
 - `width` et `height` sont strictement positifs et multiples de la géométrie d'une dalle.
 - `firmwareVersion`, `protocolVersion`, `status`, `lastSeenAt` et `ipAddress` sont **observés**, jamais saisis.
 - Un device appartient à un utilisateur ; son renderer peut appartenir à un autre utilisateur uniquement s'il

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -23,8 +23,8 @@ une géométrie et un état. Un device se connecte à **un** renderer.
 **Scene** — Un contenu à afficher, décrit par une configuration versionnée et validée. Une scène est une donnée,
 pas un processus. Plusieurs devices peuvent afficher la même scène.
 
-**Simulateur** — Une page web de debug qui remplace le matériel : elle parle le protocole device et peint les
-frames sur un canvas. C'est un **device**, pas une prévisualisation.
+**Simulateur** — Une page du dashboard Nuxt qui remplace le matériel : elle parle le protocole device et peint
+les frames sur un canvas. C'est un **device**, pas une prévisualisation.
 
 ---
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -20,8 +20,13 @@ existe deux sortes, qui parlent le même protocole :
 **Device** — Un appareil qui affiche : un Matrix Portal S3, ou un simulateur. Porte une identité, un credential,
 une géométrie et un état. Un device se connecte à **un** renderer.
 
-**Scene** — Un contenu à afficher, décrit par une configuration versionnée et validée. Une scène est une donnée,
-pas un processus. Plusieurs devices peuvent afficher la même scène.
+**Scene** — Un contenu à afficher, décrit par une configuration versionnée et validée, **pour une géométrie
+donnée**. Une scène est une donnée, pas un processus. Plusieurs devices peuvent afficher la même scène, à
+condition que leur géométrie en soit un multiple entier ([ADR-0018](adr/0018-geometrie-native-de-la-scene.md)).
+
+**Groupe de rendu** — L'ensemble des devices qui affichent une même scène, et pour lesquels le renderer ne
+calcule donc qu'une seule frame — quitte à l'agrandir ou à l'espacer ensuite pour chacun. C'est une notion interne au renderer : elle n'existe ni
+en base ni dans l'interface ([ADR-0017](adr/0017-rendu-mutualise.md)).
 
 **Simulateur** — Une page du dashboard Nuxt qui remplace le matériel : elle parle le protocole device et peint
 les frames sur un canvas. C'est un **device**, pas une prévisualisation.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -28,8 +28,10 @@ condition que leur géométrie en soit un multiple entier ([ADR-0018](adr/0018-g
 calcule donc qu'une seule frame — quitte à l'agrandir ou à l'espacer ensuite pour chacun. C'est une notion interne au renderer : elle n'existe ni
 en base ni dans l'interface ([ADR-0017](adr/0017-rendu-mutualise.md)).
 
-**Simulateur** — Une page du dashboard Nuxt qui remplace le matériel : elle parle le protocole device et peint
-les frames sur un canvas. C'est un **device**, pas une prévisualisation.
+**Simulateur** — Une page du dashboard Nuxt qui tient le rôle du matériel : elle parle le protocole device et
+peint les frames sur un canvas. C'est un **device** déclaré comme tel dans le registre — `kind = simulator` — et
+non l'emprunt d'identité d'une dalle, ni une prévisualisation
+([ADR-0020](adr/0020-simulateur-device-declare.md)).
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -14,7 +14,7 @@
 Formules, directement issues des en-têtes du protocole :
 
 ```
-FULL   = 10 + largeur × hauteur × 3   octets
+FULL   = 9 + largeur × hauteur × 3   octets
 DELTA  = 7  + 5 × pixels_modifiés     octets
 ```
 
@@ -28,12 +28,12 @@ la ligne correspondante, un device à 60 FPS le double.
 
 | Géométrie | Pixels | FULL | Débit @30 FPS | |
 |-----------|--------|------|---------------|---|
-| 32×32 | 1 024 | 3 082 o | 90,3 Kio/s | 0,74 Mbit/s |
-| **64×32** | **2 048** | **6 154 o** | **180,3 Kio/s** | **1,48 Mbit/s** |
-| 64×64 | 4 096 | 12 298 o | 360,3 Kio/s | 2,95 Mbit/s |
-| 128×64 | 8 192 | 24 586 o | 720,3 Kio/s | 5,90 Mbit/s |
-| 128×128 | 16 384 | 49 162 o | 1,41 Mio/s | 11,8 Mbit/s |
-| 256×256 | 65 536 | 196 618 o | 5,63 Mio/s | 47,2 Mbit/s |
+| 32×32 | 1 024 | 3 081 o | 90,3 Kio/s | 0,74 Mbit/s |
+| **64×32** | **2 048** | **6 153 o** | **180,3 Kio/s** | **1,48 Mbit/s** |
+| 64×64 | 4 096 | 12 297 o | 360,3 Kio/s | 2,95 Mbit/s |
+| 128×64 | 8 192 | 24 585 o | 720,3 Kio/s | 5,90 Mbit/s |
+| 128×128 | 16 384 | 49 161 o | 1,41 Mio/s | 11,8 Mbit/s |
+| 256×256 | 65 536 | 196 617 o | 5,63 Mio/s | 47,2 Mbit/s |
 
 256×256 est le maximum absolu du protocole, imposé par l'index de pixel sur 16 bits.
 
@@ -48,7 +48,7 @@ Pour une dalle 64×32, à 30 FPS :
 | 25 % (512 px) | 2 567 o | 75,2 Kio/s | ÷ 2,4 |
 | 60 % (1 229 px) | 6 152 o | 180,2 Kio/s | ≈ égal |
 
-**Point de bascule** : le mode différentiel cesse d'être rentable à `(3P + 3) / 5` pixels modifiés, soit environ
+**Point de bascule** : le mode différentiel cesse d'être rentable à `(3P + 2) / 5` pixels modifiés, soit environ
 **60 % des pixels**. Le renderer n'a pas besoin de ce chiffre — il compare directement les deux tailles avant
 chaque envoi ([PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md#arbitrage-full--delta)) — mais il éclaire les ordres de
 grandeur.
@@ -124,7 +124,7 @@ Rien de ce qui précède ne remplace une mesure. Ce qu'il faut relever, et comme
 `fps`, `frames_applied`, `last_applied_sequence`, `free_heap`, `free_psram`, `wifi_rssi`.
 
 **Latence de bout en bout** : différence entre la séquence émise par le renderer et le `last_applied_sequence`
-remonté, multipliée par la période de frame. C'est la mesure la plus utile du système, et elle ne coûte rien —
+remonté — modulo 2³², le compteur bouclant — multipliée par la période de frame de ce device. C'est la mesure la plus utile du système, et elle ne coûte rien —
 elle tombe du protocole existant.
 
 ### Côté renderer

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -18,6 +18,11 @@ FULL   = 10 + largeur × hauteur × 3   octets
 DELTA  = 7  + 5 × pixels_modifiés     octets
 ```
 
+**Les débits ci-dessous sont donnés à 30 FPS parce que c'est la cadence par défaut, pas parce qu'elle est
+figée.** `targetFps` se règle par device, de 1 à 60 ([ADR-0001](adr/0001-streaming-de-frames.md)) ; la taille
+d'une frame n'en dépend pas, le débit lui est directement proportionnel. Un device à 10 FPS consomme le tiers de
+la ligne correspondante, un device à 60 FPS le double.
+
 ### Frame complète, à 30 FPS
 
 | Géométrie | Pixels | FULL | Débit @30 FPS | |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -19,7 +19,8 @@ DELTA  = 7  + 5 × pixels_modifiés     octets
 ```
 
 **Les débits ci-dessous sont donnés à 30 FPS parce que c'est la cadence par défaut, pas parce qu'elle est
-figée.** `targetFps` se règle par device, de 1 à 60 ([ADR-0001](adr/0001-streaming-de-frames.md)) ; la taille
+figée.** La cadence se règle par scène, de 1 à 60, et se plafonne par device
+([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) ; la taille
 d'une frame n'en dépend pas, le débit lui est directement proportionnel. Un device à 10 FPS consomme le tiers de
 la ligne correspondante, un device à 60 FPS le double.
 
@@ -76,6 +77,11 @@ C'est le coût assumé de [ADR-0001](adr/0001-streaming-de-frames.md), et la rai
 | **Total** | **28 ms** — marge 5 ms |
 
 Ces valeurs servent à décider où regarder quand la cadence décroche, pas à affirmer que la cadence tient.
+
+**Cette répartition est donnée à la cadence par défaut, pas à toutes.** À 60 FPS la frame ne dispose plus
+que de 16,7 ms et le total ci-dessus est dépassé : un device réglé au-delà de 30 FPS n'est pas couvert par
+ce budget. Le reprendre par cadence n'aurait pas de sens avant d'avoir mesuré, puisqu'aucune de ces lignes
+n'a été relevée — voir [À remplir](#à-remplir).
 
 ## Architecture temps réel du firmware — budget
 

--- a/docs/PROTOCOL-CONTROL.md
+++ b/docs/PROTOCOL-CONTROL.md
@@ -67,14 +67,19 @@ Premier message après l'ouverture. Il porte l'identité, les capacités et **la
       "max_devices": 32,
       "max_pixels_per_device": 65536
     },
-    "endpoint": "wss://renderer.lan:8889",
+    "endpoints": ["wss://renderer.lan:8889", "ws://192.168.1.50:8889"],
     "state_version": 41
   }
 }
 ```
 
-`version`, `capabilities` et `endpoint` sont **déclarés par le renderer**. Ce sont des données non fiables :
+`version`, `capabilities` et `endpoints` sont **déclarés par le renderer**. Ce sont des données non fiables :
 Adonis les valide et les borne avant de les persister ([ARCHITECTURE.md](ARCHITECTURE.md#frontière-de-confiance)).
+
+`endpoints` est une **liste** : un renderer peut être joignable en `wss://`, en `ws://`, ou les deux. Adonis la
+transmet telle quelle au bootstrap et **ne choisit pas** à la place du client
+([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)). Il ne peut d'ailleurs rien vérifier : un renderer
+auto-hébergé lui est injoignable.
 
 `state_version` est le pivot de la resynchronisation.
 
@@ -213,11 +218,19 @@ Le renderer met en cache les empreintes de tokens device pour rester autonome. U
 instantanée. Trois mécanismes bornent la fenêtre :
 
 1. **Événement immédiat** — `device.revoked` est traité dès réception, connexion fermée.
-2. **Durée de validité du cache** — une entrée non revalidée expire. Passé ce délai, le renderer refuse les
-   nouvelles connexions du device concerné, mais ne coupe pas celles déjà établies.
-3. **Comportement hors ligne** — un renderer déconnecté de la plateforme continue de servir les devices déjà
-   authentifiés sur son cache. C'est le compromis explicite de [ADR-0008](adr/0008-renderer-autonome.md) : la
-   dalle du salon survit à une panne, au prix d'un délai de révocation.
+2. **Bail de session** — chaque device porte un `offlineGrace`. Passé ce délai sans contact de contrôle
+   réussi, le renderer ferme la connexion avec `ERROR 0x09` et refuse les reconnexions jusqu'au rétablissement.
+   La coupure vise **aussi les connexions établies** : le lien renderer → device étant permanent
+   ([ADR-0001](adr/0001-streaming-de-frames.md)), une expiration qui ne filtrerait que les reconnexions ne
+   s'appliquerait jamais à une dalle allumée ([ADR-0015](adr/0015-bail-de-session-device.md)).
+3. **Comportement hors ligne** — un renderer déconnecté continue de servir les devices déjà authentifiés dont le
+   bail court encore. C'est le compromis explicite de [ADR-0008](adr/0008-renderer-autonome.md) : la dalle du
+   salon survit à une panne, au prix d'un délai de révocation — mais ce délai est désormais fini et réglable par
+   dalle, au lieu d'être illimité.
+
+Le déclencheur du point 2 est **l'absence de contact**, non la réception d'un message : un `device.revoked` ne
+peut pas traverser un canal coupé, et c'est précisément quand le canal est coupé qu'on ne peut plus rien
+révoquer.
 
 Une révocation vraiment immédiate imposerait de déléguer la validation à Adonis, alternative écartée parce
 qu'elle éteindrait toutes les dalles en cas de panne de la plateforme.

--- a/docs/PROTOCOL-CONTROL.md
+++ b/docs/PROTOCOL-CONTROL.md
@@ -3,7 +3,8 @@
 > **Version de l'enveloppe** : 1
 > Décisions : [ADR-0007](adr/0007-plan-de-controle-wss.md) (WSS sortant, JSON versionné),
 > [ADR-0004](adr/0004-device-vers-renderer.md) (Adonis seul propriétaire de la base),
-> [ADR-0008](adr/0008-renderer-autonome.md) (autonomie hors ligne).
+> [ADR-0008](adr/0008-renderer-autonome.md) (autonomie hors ligne),
+> [ADR-0017](adr/0017-rendu-mutualise.md) (scènes normalisées dans le registre).
 
 Ce document spécifie le canal entre un **renderer** et **AdonisJS** : configuration et registre dans un sens,
 état dans l'autre.
@@ -124,13 +125,18 @@ Télémétrie agrégée du renderer : nombre de devices servis, frames émises, 
 
 ### `sync.full`
 
-Registre complet des devices assignés à ce renderer, avec leurs scènes. Réponse par défaut à `renderer.hello`.
+Registre complet des devices assignés à ce renderer, et des scènes qu'ils référencent. Réponse par défaut à
+`renderer.hello`.
 
 ```jsonc
 {
   "v": 1, "type": "sync.full", "id": "…",
   "payload": {
     "state_version": 47,
+    "scenes": [
+      { "scene_id": "…", "version": 12, "width": 64, "height": 32, "target_fps": 30,
+        "config": { "version": 1, "nodes": [] } }
+    ],
     "devices": [
       {
         "device_id": "…",
@@ -139,13 +145,32 @@ Registre complet des devices assignés à ce renderer, avec leurs scènes. Répo
         "panel_type": "hub75",
         "width": 64, "height": 32, "chain_length": 1,
         "brightness": 128,
-        "target_fps": 30,
-        "scene": { "scene_id": "…", "version": 12, "config": { "version": 1, "nodes": [] } }
+        "max_fps": null,
+        "scene_id": "…"
       }
     ]
   }
 }
 ```
+
+**Les scènes sont une section à part, et un device n'en porte que la référence.** Le modèle lie déjà N devices à
+une scène ([DATA-MODEL.md](DATA-MODEL.md#scene)) ; recopier la configuration dans chaque entrée de device aurait
+autorisé deux copies divergentes d'une même scène en une même version, et aurait présenté comme N contenus
+indépendants ce que le renderer doit calculer une seule fois ([ADR-0017](adr/0017-rendu-mutualise.md)).
+
+Une scène porte **sa** géométrie, distincte de celle du device : le renderer l'évalue en natif puis réplique
+chaque pixel en un bloc `k×k`, où `k` est le rapport entier entre les deux
+([ADR-0018](adr/0018-geometrie-native-de-la-scene.md)). Adonis n'assigne jamais une paire dont le rapport n'est
+pas un entier identique sur les deux axes ; le renderer qui en reçoit une malgré tout refuse la scène et
+journalise, il ne redimensionne pas au mieux.
+
+**La cadence est portée par la scène**, `max_fps` n'étant qu'un plafond d'émission par device — `null` la
+plupart du temps ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)). Le renderer évalue à `target_fps` et
+n'émet qu'une frame sur `n = ⌈target_fps / max_fps⌉` vers un device plafonné.
+
+`scene_id` vaut `null` pour un device sans scène assignée — écran noir. Tout `scene_id` référencé par un device
+**doit** figurer dans `scenes` ; un message qui référence une scène absente est rejeté en entier plutôt
+qu'appliqué partiellement. Une scène qu'aucun device ne référence n'est pas envoyée.
 
 Le renderer reçoit **l'empreinte** du token, jamais le token. C'est ce qui rend acceptable sa réplication chez un
 tiers ([DATA-MODEL.md](DATA-MODEL.md#credentials)).
@@ -160,13 +185,15 @@ multi-tenant, cette restriction est la frontière d'isolation entre utilisateurs
 
 ### `sync.delta`
 
-Changements depuis un `state_version` donné, quand Adonis peut les calculer. Même forme, restreinte aux entrées
-modifiées, avec les suppressions listées.
+Changements depuis un `state_version` donné, quand Adonis peut les calculer. Même forme — les deux sections
+`scenes` et `devices` — restreinte aux entrées modifiées, avec les suppressions listées. Une scène modifiée y
+figure **une fois**, quel que soit le nombre de devices qui la référencent.
 
 ### `device.assigned` / `device.unassigned`
 
 Un device entre ou sort du périmètre de ce renderer. À la désassignation, le renderer ferme la connexion du
-device et **purge son entrée de cache**.
+device et **purge son entrée de cache**. Il purge aussi la scène référencée s'il était le dernier device à la
+référencer.
 
 ### `device.revoked`
 
@@ -180,13 +207,26 @@ Le renderer ferme immédiatement la connexion concernée avec `ERROR 0x09` et re
 
 ### `scene.updated`
 
-La scène assignée à un ou plusieurs devices a changé. Porte la configuration complète et sa version — pas un
-diff : une scène est petite, et un diff introduirait un état intermédiaire à gérer.
+Une scène a changé. Le message porte la scène, pas les devices : il est émis **une fois**, et le renderer
+l'applique à tous les devices qui la référencent — il les connaît par son registre.
+
+```jsonc
+{
+  "v": 1, "type": "scene.updated", "id": "…",
+  "payload": { "scene_id": "…", "version": 13, "width": 64, "height": 32, "target_fps": 30,
+               "config": { "version": 1, "nodes": [] } }
+}
+```
+
+La configuration est complète, jamais un diff : une scène est petite, et un diff introduirait un état
+intermédiaire à gérer.
 
 ### `config.updated`
 
-Changement de luminosité ou de cadence sans changement de scène. Se traduit par un `CONFIG` sur le chemin device,
-sans reconnexion.
+Changement de luminosité ou de plafond d'émission sans changement de scène. Se traduit par un `CONFIG` sur le
+chemin device, sans reconnexion. Un changement de **cadence** relève de `scene.updated`, puisque la cadence
+appartient à la scène — mais il produit lui aussi un `CONFIG`, la cadence effective de chaque device en
+dépendant.
 
 ---
 

--- a/docs/PROTOCOL-CONTROL.md
+++ b/docs/PROTOCOL-CONTROL.md
@@ -205,6 +205,25 @@ Le credential d'un device n'est plus valide.
 
 Le renderer ferme immédiatement la connexion concernée avec `ERROR 0x09` et retire l'empreinte de son cache.
 
+### `device.credential_rotated`
+
+Le credential d'un device a été remplacé. Le renderer met à jour son entrée de cache et **ferme la connexion en
+cours** avec `ERROR 0x09` : le token qu'elle avait présenté n'est plus valide.
+
+```jsonc
+{
+  "v": 1, "type": "device.credential_rotated", "id": "…",
+  "payload": { "device_id": "…", "token_prefix": "71ce04ba82df", "token_hash": "scrypt$…" }
+}
+```
+
+C'est la réponse à une fuite pour n'importe quel device ([ADR-0012](adr/0012-format-des-tokens.md)), et le moyen
+par lequel le simulateur obtient à l'ouverture un token utilisable, puisque aucun secret n'est relisible
+([ADR-0021](adr/0021-credential-du-simulateur-par-rotation.md)).
+
+Adonis émet cet événement **avant** de rendre le secret à son demandeur, et refuse la rotation quand le renderer
+est hors ligne : un secret que le renderer ne peut pas apprendre ne servirait qu'à détruire le précédent.
+
 ### `scene.updated`
 
 Une scène a changé. Le message porte la scène, pas les devices : il est émis **une fois**, et le renderer

--- a/docs/PROTOCOL-CONTROL.md
+++ b/docs/PROTOCOL-CONTROL.md
@@ -259,7 +259,7 @@ instantanée. Trois mécanismes bornent la fenêtre :
 
 1. **Événement immédiat** — `device.revoked` est traité dès réception, connexion fermée.
 2. **Bail de session** — chaque device porte un `offlineGrace`. Passé ce délai sans contact de contrôle
-   réussi, le renderer ferme la connexion avec `ERROR 0x09` et refuse les reconnexions jusqu'au rétablissement.
+   réussi, le renderer ferme la connexion avec `ERROR 0x0A` et refuse les reconnexions jusqu'au rétablissement.
    La coupure vise **aussi les connexions établies** : le lien renderer → device étant permanent
    ([ADR-0001](adr/0001-streaming-de-frames.md)), une expiration qui ne filtrerait que les reconnexions ne
    s'appliquerait jamais à une dalle allumée ([ADR-0015](adr/0015-bail-de-session-device.md)).

--- a/docs/PROTOCOL-DEVICE.md
+++ b/docs/PROTOCOL-DEVICE.md
@@ -208,11 +208,14 @@ luminosité seul se transmet par `CONFIG`.
 | 2 | 2 | u16 | `width` faisant autorité |
 | 4 | 2 | u16 | `height` faisant autorité |
 | 6 | 1 | u8 | `brightness` (0–255) |
-| 7 | 1 | u8 | `target_fps` — 1 à 60 ([ADR-0001](adr/0001-streaming-de-frames.md)) |
+| 7 | 1 | u8 | `target_fps` — cadence **effective** de ce device, 1 à 60 ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) |
 | 8 | 2 | u16 | `status_interval_s` — période des `STATUS_UPDATE` |
 | 10 | 4 | u32 | `session_id` |
 
 **Total = 14 octets**
+
+La cadence transmise ici est celle de la scène, éventuellement divisée par le plafond du device. Le calcul est
+fait par Adonis : le device reçoit un seul chiffre et n'arbitre rien.
 
 `CONFIG` peut être renvoyé à tout moment pour modifier luminosité ou cadence sans rouvrir la connexion. Un
 changement de géométrie, lui, impose une reconnexion.

--- a/docs/PROTOCOL-DEVICE.md
+++ b/docs/PROTOCOL-DEVICE.md
@@ -37,11 +37,16 @@ Authorization: Bearer <token device>
 
 ```jsonc
 {
-  "renderer_url": "wss://renderer.example.net:8889",
+  "renderer_urls": ["wss://renderer.example.net:8889", "ws://192.168.1.50:8889"],
   "panel": { "width": 64, "height": 32, "chain": 1 },
   "scene_version": 42
 }
 ```
+
+`renderer_urls` est la liste déclarée par le renderer, transmise telle quelle. **Le client choisit** : un
+firmware retient `wss://` s'il est présent et `ws://` sinon ; le simulateur ne retient que ce que le navigateur
+autorise depuis l'origine de la page qui le sert
+([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)).
 
 Le device **met cette réponse en cache localement** et repart dessus si la plateforme ne répond pas au
 redémarrage suivant. Sans ce cache, une panne de la plateforme empêcherait tout redémarrage, ce qui contredirait
@@ -109,6 +114,17 @@ Si un device déjà connecté ouvre une seconde connexion, **la nouvelle remplac
 Cette règle est nécessaire indépendamment du simulateur : après une coupure WiFi, l'ancienne socket reste
 souvent ouverte côté renderer, et sans cette règle le device se retrouverait incapable de se reconnecter jusqu'à
 expiration du keep-alive TCP.
+
+### Expiration du bail
+
+Le droit de recevoir des frames est un **bail**, borné par l'`offlineGrace` du device
+([ADR-0015](adr/0015-bail-de-session-device.md)). Quand le renderer est resté sans contact avec la plateforme
+plus longtemps que cette durée, il ferme la connexion avec `ERROR 0x09`, **y compris une connexion établie de
+longue date**. Les reconnexions sont ensuite refusées avec le même code tant que le contact n'est pas rétabli.
+
+`0x09` n'est pas `0x04` : le token reste valide, c'est le renderer qui n'est plus en mesure de l'affirmer.
+L'état est transitoire et se résout dès que la plateforme redevient joignable. Le device réessaie donc avec un
+retrait exponentiel plafonné, sans considérer son credential comme perdu.
 
 ---
 
@@ -192,7 +208,7 @@ luminosité seul se transmet par `CONFIG`.
 | 2 | 2 | u16 | `width` faisant autorité |
 | 4 | 2 | u16 | `height` faisant autorité |
 | 6 | 1 | u8 | `brightness` (0–255) |
-| 7 | 1 | u8 | `target_fps` |
+| 7 | 1 | u8 | `target_fps` — 1 à 60 ([ADR-0001](adr/0001-streaming-de-frames.md)) |
 | 8 | 2 | u16 | `status_interval_s` — période des `STATUS_UPDATE` |
 | 10 | 4 | u32 | `session_id` |
 
@@ -248,6 +264,7 @@ est une source classique de dépassement de lecture.
 | `0x06` | Version de protocole non supportée |
 | `0x07` | Allocation mémoire impossible |
 | `0x08` | Connexion remplacée par une plus récente |
+| `0x09` | Bail expiré : le renderer a perdu le contact avec la plateforme |
 | `0x09` | Device inconnu ou révoqué |
 
 ---

--- a/docs/PROTOCOL-DEVICE.md
+++ b/docs/PROTOCOL-DEVICE.md
@@ -64,19 +64,19 @@ Device                                              Renderer
   │  ── ouverture WebSocket (aucun credential) ────────▶│
   │                                                     │  démarre le délai
   │                                                     │  d'authentification
-  │  ── 0x03 DEVICE_HELLO (token, version, géométrie) ─▶│
+  │  ── 0x01 DEVICE_HELLO (token, version, géométrie) ─▶│
   │                                                     │  valide l'empreinte
   │                                                     │  vérifie la géométrie
-  │◀─ 0x04 CONFIG (géométrie autoritaire, fps) ─────────│
+  │◀─ 0x02 CONFIG (géométrie autoritaire, fps) ─────────│
   │                                                     │
-  │◀─ 0x01 FULL_FRAME (obligatoire en premier) ─────────│
-  │◀─ 0x02 DELTA_FRAME ─────────────────────────────────│
-  │◀─ 0x02 DELTA_FRAME ─────────────────────────────────│
+  │◀─ 0x03 FULL_FRAME (obligatoire en premier) ─────────│
+  │◀─ 0x04 DELTA_FRAME ─────────────────────────────────│
+  │◀─ 0x04 DELTA_FRAME ─────────────────────────────────│
   │  ── 0x05 STATUS_UPDATE (périodique) ───────────────▶│
   │                                                     │
 ```
 
-**En cas d'échec**, le renderer envoie un `0x08 ERROR` puis ferme la connexion. Il ne laisse jamais une
+**En cas d'échec**, le renderer envoie un `0x06 ERROR` puis ferme la connexion. Il ne laisse jamais une
 connexion non authentifiée ouverte.
 
 ### Authentification
@@ -119,10 +119,11 @@ expiration du keep-alive TCP.
 
 Le droit de recevoir des frames est un **bail**, borné par l'`offlineGrace` du device
 ([ADR-0015](adr/0015-bail-de-session-device.md)). Quand le renderer est resté sans contact avec la plateforme
-plus longtemps que cette durée, il ferme la connexion avec `ERROR 0x09`, **y compris une connexion établie de
+plus longtemps que cette durée, il ferme la connexion avec `ERROR 0x0A`, **y compris une connexion établie de
 longue date**. Les reconnexions sont ensuite refusées avec le même code tant que le contact n'est pas rétabli.
 
-`0x09` n'est pas `0x04` : le token reste valide, c'est le renderer qui n'est plus en mesure de l'affirmer.
+`0x0A` n'est ni `0x04` ni `0x09` : le token reste valide, c'est le renderer qui n'est plus en mesure de
+l'affirmer.
 L'état est transitoire et se résout dès que la plateforme redevient joignable. Le device réessaie donc avec un
 retrait exponentiel plafonné, sans considérer son credential comme perdu.
 
@@ -130,38 +131,83 @@ retrait exponentiel plafonné, sans considérer son credential comme perdu.
 
 ## Messages
 
+**Les codes suivent l'ordre de la session** : poignée de main, configuration, données, télémétrie, erreur.
+C'est l'ordre dans lequel ce document les décrit, et celui dans lequel une trace les fait apparaître.
+
 | Code | Nom | Sens | Taille |
 |------|-----|------|--------|
-| `0x01` | `FULL_FRAME` | Renderer → Device | 10 + w×h×3 |
-| `0x02` | `DELTA_FRAME` | Renderer → Device | 7 + 5×N |
-| `0x03` | `DEVICE_HELLO` | Device → Renderer | 11 + N |
-| `0x04` | `CONFIG` | Renderer → Device | 14 |
+| `0x01` | `DEVICE_HELLO` | Device → Renderer | 11 + N |
+| `0x02` | `CONFIG` | Renderer → Device | 10 |
+| `0x03` | `FULL_FRAME` | Renderer → Device | 9 + w×h×3 |
+| `0x04` | `DELTA_FRAME` | Renderer → Device | 7 + 5×N |
 | `0x05` | `STATUS_UPDATE` | Device → Renderer | 27 |
-| `0x08` | `ERROR` | Bidirectionnel | 4 + M |
+| `0x06` | `ERROR` | Bidirectionnel | 4 + M |
 
-### 0x01 — FULL_FRAME
+`0x00` n'est le code d'aucun message et ne doit jamais en devenir un : un octet nul est ce qu'on lit d'un tampon
+mal initialisé ou d'une frame tronquée, et c'est la seule valeur dont l'invalidité distingue un bug d'un message.
+
+**Les codes d'erreur forment un espace de nommage distinct.** Le `0x06` de cette table est le message `ERROR` ;
+le `0x06` de la table des codes d'erreur est « version de protocole non supportée ». Rien ne les relie, et une
+implémentation qui les confondrait n'échouerait pas bruyamment.
+
+### 0x01 — DEVICE_HELLO
 
 | Offset | Taille | Type | Champ |
 |--------|--------|------|-------|
 | 0 | 1 | u8 | Type = `0x01` |
+| 1 | 1 | u8 | `protocol_version` (= 1) |
+| 2 | 2 | u16 | `firmware_version` (majeure × 256 + mineure) |
+| 4 | 2 | u16 | `declared_width` |
+| 6 | 2 | u16 | `declared_height` |
+| 8 | 1 | u8 | `panel_type` — `0x00` = HUB75 |
+| 9 | 1 | u8 | `flags` — bit 0 : device simulé |
+| 10 | 1 | u8 | `token_len` (N) |
+| 11 | N | u8[] | `token`, ASCII, **sans terminateur** |
+
+**Total = 11 + N**
+
+### 0x02 — CONFIG
+
+| Offset | Taille | Type | Champ |
+|--------|--------|------|-------|
+| 0 | 1 | u8 | Type = `0x02` |
+| 1 | 1 | u8 | `protocol_version` retenue |
+| 2 | 2 | u16 | `width` faisant autorité |
+| 4 | 2 | u16 | `height` faisant autorité |
+| 6 | 1 | u8 | `brightness` (0–255) |
+| 7 | 1 | u8 | `target_fps` — cadence **effective** de ce device, 1 à 60 ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) |
+| 8 | 2 | u16 | `status_interval_s` — période des `STATUS_UPDATE` |
+
+**Total = 10 octets**
+
+La cadence transmise ici est celle de la scène, éventuellement divisée par le plafond du device. Le calcul est
+fait par Adonis : le device reçoit un seul chiffre et n'arbitre rien.
+
+`CONFIG` peut être renvoyé à tout moment pour modifier luminosité ou cadence sans rouvrir la connexion. Un
+changement de géométrie, lui, impose une reconnexion.
+
+### 0x03 — FULL_FRAME
+
+| Offset | Taille | Type | Champ |
+|--------|--------|------|-------|
+| 0 | 1 | u8 | Type = `0x03` |
 | 1 | 4 | u32 | `sequence` |
 | 5 | 2 | u16 | `width` |
 | 7 | 2 | u16 | `height` |
-| 9 | 1 | u8 | `brightness` (0–255) |
-| 10 | w×h×3 | u8[] | RGB888, **row-major** |
+| 9 | w×h×3 | u8[] | RGB888, **row-major** |
 
-**Total = 10 + (width × height × 3)** — soit 6 154 octets en 64×32.
+**Total = 9 + (width × height × 3)** — soit 6 153 octets en 64×32.
 
 Ordre des pixels : ligne par ligne, de gauche à droite et de haut en bas. `index = y × width + x`.
 
 Le device **doit** rejeter la frame si `width` ou `height` diffèrent de sa configuration, ou si la taille du
 message ne correspond pas à la formule. C'est la dernière barrière contre un débordement de tampon.
 
-### 0x02 — DELTA_FRAME
+### 0x04 — DELTA_FRAME
 
 | Offset | Taille | Type | Champ |
 |--------|--------|------|-------|
-| 0 | 1 | u8 | Type = `0x02` |
+| 0 | 1 | u8 | Type = `0x04` |
 | 1 | 4 | u32 | `sequence` |
 | 5 | 2 | u16 | `count` (N) |
 | 7 | 5 × N | — | N entrées consécutives |
@@ -180,45 +226,31 @@ Chaque entrée fait 5 octets :
 L'index sur 16 bits **plafonne une dalle à 65 536 pixels**, soit 256×256. Cette limite est structurelle : la
 dépasser impose une version 2 du protocole.
 
-Une `DELTA_FRAME` hérite de la `brightness` de la dernière `FULL_FRAME` ou du dernier `CONFIG`. Un changement de
-luminosité seul se transmet par `CONFIG`.
+**Aucune frame ne porte la luminosité** : elle n'est transportée que par `CONFIG`, qui en est la seule source.
+La faire voyager aussi dans l'en-tête d'une frame imposerait une règle de précédence, et donc un défaut — une
+frame calculée avant un changement de luminosité écraserait le réglage frais en arrivant après lui. La
+luminosité est un réglage du device, pas un attribut de l'image : une scène qui veut fondre au noir assombrit
+ses pixels.
 
-### 0x03 — DEVICE_HELLO
+### Le compteur `sequence`
 
-| Offset | Taille | Type | Champ |
-|--------|--------|------|-------|
-| 0 | 1 | u8 | Type = `0x03` |
-| 1 | 1 | u8 | `protocol_version` (= 1) |
-| 2 | 2 | u16 | `firmware_version` (majeure × 256 + mineure) |
-| 4 | 2 | u16 | `declared_width` |
-| 6 | 2 | u16 | `declared_height` |
-| 8 | 1 | u8 | `panel_type` — `0x00` = HUB75 |
-| 9 | 1 | u8 | `flags` — bit 0 : device simulé |
-| 10 | 1 | u8 | `token_len` (N) |
-| 11 | N | u8[] | `token`, ASCII, **sans terminateur** |
+Les deux types de frame portent le même compteur, et il obéit à trois règles :
 
-**Total = 11 + N**
+- **Il appartient à la connexion d'un device**, pas à la scène ni au groupe de rendu. Le renderer l'incrémente de
+  1 à chaque frame **réellement envoyée à ce device**, quel que soit son type. Un device plafonné
+  ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) ne voit donc aucun trou : les frames qu'il ne reçoit pas
+  ne lui ont jamais été numérotées. Deux devices d'un même groupe ont des compteurs indépendants, et c'est
+  nécessaire — un compteur partagé rendrait faux le calcul de latence, qui multiplie un écart de séquence par une
+  période de frame.
+- **Il repart de 0 à chaque connexion**, sur la `FULL_FRAME` obligatoire qui ouvre la session. Le device n'a donc
+  aucun état à conserver d'une session à l'autre, et une reconnexion ne se distingue pas d'un premier démarrage.
+- **Il boucle modulo 2³²**, ce qui laisse environ deux ans et demi de session continue à 60 FPS. La comparaison
+  avec `last_applied_sequence` doit se faire modulo, sans quoi ce bouclage produirait une latence aberrante une
+  fois par éternité.
 
-### 0x04 — CONFIG
-
-| Offset | Taille | Type | Champ |
-|--------|--------|------|-------|
-| 0 | 1 | u8 | Type = `0x04` |
-| 1 | 1 | u8 | `protocol_version` retenue |
-| 2 | 2 | u16 | `width` faisant autorité |
-| 4 | 2 | u16 | `height` faisant autorité |
-| 6 | 1 | u8 | `brightness` (0–255) |
-| 7 | 1 | u8 | `target_fps` — cadence **effective** de ce device, 1 à 60 ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) |
-| 8 | 2 | u16 | `status_interval_s` — période des `STATUS_UPDATE` |
-| 10 | 4 | u32 | `session_id` |
-
-**Total = 14 octets**
-
-La cadence transmise ici est celle de la scène, éventuellement divisée par le plafond du device. Le calcul est
-fait par Adonis : le device reçoit un seul chiffre et n'arbitre rien.
-
-`CONFIG` peut être renvoyé à tout moment pour modifier luminosité ou cadence sans rouvrir la connexion. Un
-changement de géométrie, lui, impose une reconnexion.
+Le device ne fait rien d'autre que le mémoriser et le renvoyer : ni détection de trou, ni demande de
+retransmission. L'ordre et l'intégrité sont garantis par TCP ([ADR-0003](adr/0003-websocket-binaire-tcp.md)), et
+une frame perdue serait de toute façon remplacée par la suivante avant d'être utile.
 
 ### 0x05 — STATUS_UPDATE
 
@@ -243,11 +275,11 @@ Trois métriques des versions antérieures ont été retirées : la **tension d'
 CPU**, faute de capteur fiable sur le matériel de référence, et le **compteur de paquets perdus**, sans objet
 sur TCP. Une métrique inventée est pire qu'une métrique absente.
 
-### 0x08 — ERROR
+### 0x06 — ERROR
 
 | Offset | Taille | Type | Champ |
 |--------|--------|------|-------|
-| 0 | 1 | u8 | Type = `0x08` |
+| 0 | 1 | u8 | Type = `0x06` |
 | 1 | 1 | u8 | `code` |
 | 2 | 2 | u16 | `msg_len` (M) |
 | 4 | M | u8[] | Message UTF-8, **sans terminateur** |
@@ -256,6 +288,8 @@ sur TCP. Une métrique inventée est pire qu'une métrique absente.
 
 La longueur est explicite plutôt que délimitée par un octet nul : chercher un terminateur dans un flux binaire
 est une source classique de dépassement de lecture.
+
+`0x00` n'est le code d'aucune erreur, comme il n'est le code d'aucun message.
 
 | Code | Signification |
 |------|---------------|
@@ -267,8 +301,8 @@ est une source classique de dépassement de lecture.
 | `0x06` | Version de protocole non supportée |
 | `0x07` | Allocation mémoire impossible |
 | `0x08` | Connexion remplacée par une plus récente |
-| `0x09` | Bail expiré : le renderer a perdu le contact avec la plateforme |
 | `0x09` | Device inconnu ou révoqué |
+| `0x0A` | Bail expiré : le renderer a perdu le contact avec la plateforme |
 
 ---
 
@@ -277,7 +311,7 @@ est une source classique de dépassement de lecture.
 Avant chaque envoi, le renderer calcule les deux tailles et **envoie la plus petite** :
 
 ```
-fullSize  = 10 + width × height × 3
+fullSize  = 9 + width × height × 3
 deltaSize = 7  + 5 × nombre_de_pixels_modifiés
 
 si   aucun pixel modifié       → n'envoyer rien
@@ -287,7 +321,7 @@ sinon                          → FULL_FRAME
 
 La règle est **exacte** : elle compare les deux coûts réels au lieu d'approcher le point de bascule par un seuil
 en pourcentage. Le point d'équilibre s'en déduit — le mode différentiel cesse d'être rentable au-delà de
-`(3 × width × height + 3) / 5` pixels modifiés, soit environ 60 % des pixels.
+`(3 × width × height + 2) / 5` pixels modifiés, soit environ 60 % des pixels.
 
 Cas particuliers, à respecter impérativement :
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@
 |---|---|
 | Matériel de référence | Adafruit MatrixPortal S3 + dalle HUB75 64×32 |
 | Cadence | 30 FPS par défaut, réglable par device de 1 à 60 |
-| Frame complète 64×32 | 6 154 octets, soit 1,48 Mbit/s en flux permanent |
+| Frame complète 64×32 | 6 153 octets, soit 1,48 Mbit/s en flux permanent |
 | Géométrie maximale | 65 536 pixels (256×256), limite du protocole |
 | Ports | Nuxt 3000, Adonis 3333, renderer 8889, PostgreSQL 5432 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,4 +99,3 @@ les fonctionnalités :
 | L'agrandissement `k×k` est fait par le renderer, donc payé sur le lien le plus contraint | [ADR-0018](adr/0018-geometrie-native-de-la-scene.md) |
 | Ce que fait un renderer d'un device qui remonte des FPS très inférieures à sa cadence effective | [ADR-0019](adr/0019-cadence-portee-par-la-scene.md) |
 | Le plan de contrôle n'a aucun accusé de réception, d'où une fenêtre de course après une rotation | [ADR-0021](adr/0021-credential-du-simulateur-par-rotation.md) |
-| `width` et `height` d'un device doivent être « multiples de la géométrie d'une dalle », qu'aucun champ ne porte | [#17](https://github.com/smyllet/matrixled-ssr/issues/17) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@
 | | |
 |---|---|
 | Matériel de référence | Adafruit MatrixPortal S3 + dalle HUB75 64×32 |
-| Cadence cible | 30 FPS |
+| Cadence | 30 FPS par défaut, réglable par device de 1 à 60 |
 | Frame complète 64×32 | 6 154 octets, soit 1,48 Mbit/s en flux permanent |
 | Géométrie maximale | 65 536 pixels (256×256), limite du protocole |
 | Ports | Nuxt 3000, Adonis 3333, renderer 8889, PostgreSQL 5432 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,10 @@
 # Documentation technique
 
+> **Ces documents décrivent l'architecture cible, que le code n'implémente aujourd'hui qu'en partie.** `Renderer`
+> existe ; `Matrix` est encore là où les specs parlent de `Device` et de `Scene` ; le renderer Go, le protocole
+> binaire et le firmware n'existent pas. L'écart se lit dans les [issues](#travaux-en-cours), et il est censé se
+> réduire : une spec et un code qui divergent sont un défaut, pas un état de fait.
+
 ## Par où commencer
 
 1. **[GLOSSARY.md](GLOSSARY.md)** — le vocabulaire. Court, et il évite les contresens sur tout le reste.
@@ -14,7 +19,7 @@
 |----------|---------|
 | [GLOSSARY.md](GLOSSARY.md) | Vocabulaire du projet — un terme, un sens |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Topologie, plans contrôle/données, frontière de confiance, bootstrap |
-| [adr/](adr/) | Les 11 décisions d'architecture, avec leurs alternatives écartées |
+| [adr/](adr/) | Les décisions d'architecture, une par fichier, avec leurs alternatives écartées |
 
 ### Spécifications
 
@@ -38,9 +43,10 @@
 | | |
 |---|---|
 | Matériel de référence | Adafruit MatrixPortal S3 + dalle HUB75 64×32 |
-| Cadence | 30 FPS par défaut, réglable par device de 1 à 60 |
+| Cadence | 30 FPS par défaut, réglée **par scène** de 1 à 60, plafonnée par device ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) |
 | Frame complète 64×32 | 6 153 octets, soit 1,48 Mbit/s en flux permanent |
 | Géométrie maximale | 65 536 pixels (256×256), limite du protocole |
+| Scène → device | même géométrie, ou un multiple entier `k` identique sur les deux axes ([ADR-0018](adr/0018-geometrie-native-de-la-scene.md)) |
 | Ports | Nuxt 3000, Adonis 3333, renderer 8889, PostgreSQL 5432 |
 
 ## Conventions
@@ -76,11 +82,21 @@ en anglais, comme le reste du dépôt.
 
 ## Ce qui reste ouvert
 
-Deux sujets sont volontairement non spécifiés. Le mécanisme et le point d'extension sont en place, les valeurs
-viendront avec les fonctionnalités :
+**Volontairement non spécifié.** Le mécanisme et le point d'extension sont en place, les valeurs viendront avec
+les fonctionnalités :
 
 - **Le catalogue de primitives de scène.** L'enveloppe est versionnée et validée
   ([DATA-MODEL.md](DATA-MODEL.md#configuration-de-scène)), son contenu reste ouvert.
 - **Le vocabulaire de capacités.** Le mécanisme de négociation est spécifié
   ([PROTOCOL-CONTROL.md](PROTOCOL-CONTROL.md#négociation-de-capacités)), les valeurs se rempliront au fil des
   primitives ajoutées.
+
+**Non tranché.** Ces points sont consignés là où ils se poseront, pour être rouverts en lisant un fichier :
+
+| Sujet | Où |
+|-------|-----|
+| Les sources de données appartiennent à Adonis — décision encore `Proposé`, rien ne s'y conforme | [ADR-0014](adr/0014-sources-de-donnees-cote-adonis.md) |
+| L'agrandissement `k×k` est fait par le renderer, donc payé sur le lien le plus contraint | [ADR-0018](adr/0018-geometrie-native-de-la-scene.md) |
+| Ce que fait un renderer d'un device qui remonte des FPS très inférieures à sa cadence effective | [ADR-0019](adr/0019-cadence-portee-par-la-scene.md) |
+| Le plan de contrôle n'a aucun accusé de réception, d'où une fenêtre de course après une rotation | [ADR-0021](adr/0021-credential-du-simulateur-par-rotation.md) |
+| `width` et `height` d'un device doivent être « multiples de la géométrie d'une dalle », qu'aucun champ ne porte | [#17](https://github.com/smyllet/matrixled-ssr/issues/17) |

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -91,7 +91,7 @@ Un renderer conforme doit :
 
 - fermer immédiatement la connexion d'un device sur `device.revoked` ;
 - purger l'entrée de son cache ;
-- horodater son dernier contact de contrôle réussi, et fermer avec `ERROR 0x09` toute session dont
+- horodater son dernier contact de contrôle réussi, et fermer avec `ERROR 0x0A` toute session dont
   l'`offlineGrace` est dépassé depuis cet horodatage — **connexions établies comprises**
   ([ADR-0015](adr/0015-bail-de-session-device.md)).
 
@@ -102,7 +102,7 @@ Quand la plateforme est injoignable, un renderer conforme :
 - **continue de servir** les devices déjà authentifiés dont le bail court encore, sur son dernier état connu ;
 - **continue d'accepter** les connexions de devices dont l'empreinte est en cache et le bail valide ;
 - **refuse** les devices inconnus de son cache ;
-- **coupe** les devices dont le bail a expiré, avec `ERROR 0x09` ;
+- **coupe** les devices dont le bail a expiré, avec `ERROR 0x0A` ;
 - accumule l'état à remonter et le rejoue à la reconnexion ;
 - reconnecte avec un retrait exponentiel plafonné.
 

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -96,7 +96,9 @@ Un renderer conforme doit :
   ([ADR-0021](adr/0021-credential-du-simulateur-par-rotation.md)) ;
 - horodater son dernier contact de contrôle réussi, et fermer avec `ERROR 0x0A` toute session dont
   l'`offlineGrace` est dépassé depuis cet horodatage — **connexions établies comprises**
-  ([ADR-0015](adr/0015-bail-de-session-device.md)).
+  ([ADR-0015](adr/0015-bail-de-session-device.md)). Cet horodatage doit survivre à un redémarrage : sinon
+  relancer le renderer remet le bail à zéro, et la borne ne borne plus rien
+  ([ADR-0008](adr/0008-renderer-autonome.md)).
 
 ## Fonctionnement hors ligne
 

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -73,6 +73,12 @@ capacités affichera un résultat faux au lieu de refuser une scène.
 | `max_devices` | Nombre de devices servis simultanément |
 | `max_pixels_per_device` | Plafond de géométrie. Ne peut excéder 65 536 ([PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md)) |
 
+Le renderer déclare en outre ses **`endpoints`** : les adresses auxquelles ses devices peuvent le joindre,
+`wss://`, `ws://`, ou les deux ([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)). Sur un réseau
+local, `ws://` en clair est un choix assumé : sans certificat reconnu, un `wss://` auto-signé non épinglé
+n'apporte que du chiffrement, pas d'authentification. Déclarer aussi un `wss://` avec un certificat reconnu est
+ce qui rend le renderer atteignable depuis le simulateur du dashboard hébergé ([SIMULATOR.md](SIMULATOR.md)).
+
 Adonis refuse d'assigner ce que ces capacités ne couvrent pas, et remonte la cause à l'utilisateur.
 **Un refus explicite vaut mieux qu'un affichage faux.**
 
@@ -85,22 +91,29 @@ Un renderer conforme doit :
 
 - fermer immédiatement la connexion d'un device sur `device.revoked` ;
 - purger l'entrée de son cache ;
-- faire expirer les entrées non revalidées au-delà de leur durée de validité.
+- horodater son dernier contact de contrôle réussi, et fermer avec `ERROR 0x09` toute session dont
+  l'`offlineGrace` est dépassé depuis cet horodatage — **connexions établies comprises**
+  ([ADR-0015](adr/0015-bail-de-session-device.md)).
 
 ## Fonctionnement hors ligne
 
 Quand la plateforme est injoignable, un renderer conforme :
 
-- **continue de servir** les devices déjà authentifiés, sur son dernier état connu ;
-- **continue d'accepter** les connexions de devices dont l'empreinte est en cache et non expirée ;
+- **continue de servir** les devices déjà authentifiés dont le bail court encore, sur son dernier état connu ;
+- **continue d'accepter** les connexions de devices dont l'empreinte est en cache et le bail valide ;
 - **refuse** les devices inconnus de son cache ;
+- **coupe** les devices dont le bail a expiré, avec `ERROR 0x09` ;
 - accumule l'état à remonter et le rejoue à la reconnexion ;
 - reconnecte avec un retrait exponentiel plafonné.
 
-Il ne doit **jamais** éteindre ses dalles parce que la plateforme ne répond plus. C'est la raison d'être de
-l'auto-hébergement, et cela compense la fragilité introduite par
+Il ne doit **jamais** éteindre une dalle du seul fait que la plateforme ne répond plus. C'est la raison d'être
+de l'auto-hébergement, et cela compense la fragilité introduite par
 [ADR-0001](adr/0001-streaming-de-frames.md) — sans quoi une panne distante noircirait un écran posé à trois
 mètres de son serveur.
+
+La seule extinction admise est l'**expiration du bail** ([ADR-0015](adr/0015-bail-de-session-device.md)), et
+elle ne s'y substitue pas : son défaut de sept jours dépasse toute panne réaliste. Une dalle qui s'éteint au
+bout de quelques minutes de coupure est un renderer mal configuré, pas un renderer conforme.
 
 ## Le renderer par défaut est multi-tenant
 

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -91,6 +91,9 @@ Un renderer conforme doit :
 
 - fermer immédiatement la connexion d'un device sur `device.revoked` ;
 - purger l'entrée de son cache ;
+- remplacer l'entrée de cache et fermer la connexion en cours sur `device.credential_rotated`, avec le même
+  code `ERROR 0x09` : le token présenté par cette connexion n'est plus valide
+  ([ADR-0021](adr/0021-credential-du-simulateur-par-rotation.md)) ;
 - horodater son dernier contact de contrôle réussi, et fermer avec `ERROR 0x0A` toute session dont
   l'`offlineGrace` est dépassé depuis cet horodatage — **connexions établies comprises**
   ([ADR-0015](adr/0015-bail-de-session-device.md)).

--- a/docs/SIMULATOR.md
+++ b/docs/SIMULATOR.md
@@ -88,3 +88,23 @@ dire précisément la partie que le matériel rend pénible à observer.
 Une page du dashboard Nuxt, derrière l'authentification utilisateur. Elle récupère l'adresse du renderer par le
 même mécanisme de bootstrap que le matériel, ce qui exerce aussi ce chemin
 ([ADR-0009](adr/0009-bootstrap-par-redirection.md)).
+
+## Ce qu'il peut atteindre
+
+Le simulateur est soumis aux règles du navigateur, que le firmware ne connaît pas : une page servie en HTTPS ne
+peut ouvrir ni un `ws://`, ni un `wss://` dont le certificat n'est pas reconnu.
+
+Il ne propose donc que les `renderer_urls` compatibles avec **l'origine de la page qui le sert**
+([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)) :
+
+| Le simulateur est servi depuis | Il peut atteindre |
+|--------------------------------|-------------------|
+| `http://localhost:3000` — développement | tout : `ws://` comme `wss://`, y compris un renderer auto-hébergé sur le réseau local |
+| Le dashboard hébergé, en HTTPS | uniquement les renderers déclarant `wss://` avec un certificat reconnu — en pratique celui de la plateforme |
+
+Le cas qui justifie le simulateur — développer le renderer et le dashboard sans matériel — tombe dans la
+première ligne. La contrainte ne mord que sur le dashboard hébergé.
+
+Quand aucune URL n'est utilisable, le simulateur doit le **dire** plutôt que d'échouer à la connexion : Adonis ne
+peut pas vérifier ce qu'un renderer déclare, donc un `wss://` annoncé peut très bien présenter un certificat que
+le navigateur refuse. Nommer la cause probable vaut mieux qu'une socket qui se ferme sans explication.

--- a/docs/SIMULATOR.md
+++ b/docs/SIMULATOR.md
@@ -1,10 +1,11 @@
 # Simulateur
 
-> Décision liée : [ADR-0011](adr/0011-auth-premier-message.md).
+> Décisions liées : [ADR-0011](adr/0011-auth-premier-message.md) (authentification),
+> [ADR-0020](adr/0020-simulateur-device-declare.md) (un device déclaré).
 > Protocole implémenté : [PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md).
 
-Une page web de debug qui **remplace le matériel** : elle parle le protocole device au renderer et peint les
-frames reçues sur un canvas.
+Une page web de debug qui **tient le rôle du matériel** : elle parle le protocole device au renderer et peint
+les frames reçues sur un canvas.
 
 ## Ce que c'est, et ce que ce n'est pas
 
@@ -54,26 +55,37 @@ pas. Cette règle fait partie de la relecture de conformité de
 
 ## Place dans le modèle
 
-Un simulateur est un `Device` du registre comme un autre : token, géométrie, renderer assigné. Le drapeau
-`isSimulator` sert uniquement à le distinguer dans l'interface.
+Un simulateur est un `Device` du registre comme un autre : token, géométrie, renderer assigné. Il se **déclare**
+comme tel — `kind = simulator`, choisi à la création — et n'emprunte l'identité d'aucune dalle
+([ADR-0020](adr/0020-simulateur-device-declare.md)).
 
-**Aucun cas particulier côté renderer.** Il n'a pas à savoir s'il parle à du silicium ou à un onglet — c'est
-d'ailleurs la condition pour que le simulateur teste quelque chose d'utile.
+C'est ce qui sépare observer de déranger. Pour voir ce qu'affiche une dalle, on crée un device simulateur et on
+lui assigne la même scène : le renderer les place dans le **même groupe de rendu**
+([ADR-0017](adr/0017-rendu-mutualise.md)) et ne calcule qu'une frame pour les deux. À géométrie et `maxFps`
+identiques, le simulateur reçoit donc ce que reçoit la dalle — au `sequence` près, qui appartient à chaque
+connexion, et à l'arbitrage `FULL`/`DELTA` près, qui dépend de l'historique de chacune.
+
+Ce n'est pas pour autant un miroir de la connexion de la dalle : un défaut qui ne se produit que sur *sa* socket
+ne se voit pas ici.
+
+**Aucun cas particulier côté renderer.** `kind` ne lui est même pas transmis : il n'a pas à savoir s'il parle à
+du silicium ou à un onglet — c'est d'ailleurs la condition pour que le simulateur teste quelque chose d'utile.
 
 ## Interaction avec la règle de connexion unique
 
-Simulateur et matériel peuvent revendiquer le même device. La règle **une seule connexion active par device**
-([PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md#une-seule-connexion-active-par-device)) devient donc immédiatement
-observable : ouvrir le simulateur sur un device allumé coupe la dalle, et inversement.
+La règle **une seule connexion active par device**
+([PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md#une-seule-connexion-active-par-device)) vaut pour le simulateur comme
+pour le reste : deux onglets ouverts sur le même device simulateur se coupent l'un l'autre, le dernier arrivé
+gagnant.
 
-Ce n'est pas un effet de bord regrettable, c'est le comportement voulu, et le simulateur le rend visible au lieu
-de le laisser dormir jusqu'au jour où un ESP32 se reconnecte après une coupure WiFi.
-
-Pour observer un device sans le déranger, il faut créer un second device dédié.
+Elle reste donc immédiatement observable, mais sans qu'ouvrir le simulateur n'éteigne une dalle — un device
+simulateur ne partage son identité avec aucun matériel. Et elle garde sa raison d'être propre : après une
+coupure WiFi, l'ancienne socket reste souvent ouverte côté renderer, et sans cette règle le device serait
+incapable de se reconnecter.
 
 ## Attendus fonctionnels
 
-- Saisie ou sélection d'un device et de son token.
+- Sélection d'un device `kind = simulator` parmi ceux de l'utilisateur, et saisie de son token.
 - Connexion, affichage de la phase de handshake et des erreurs reçues.
 - Rendu des frames sur un canvas, avec zoom — un pixel de dalle occupe plusieurs pixels d'écran.
 - Affichage des compteurs : FPS reçues, dernière séquence, part de `FULL` et de `DELTA`, octets reçus.

--- a/docs/SIMULATOR.md
+++ b/docs/SIMULATOR.md
@@ -83,9 +83,37 @@ simulateur ne partage son identité avec aucun matériel. Et elle garde sa raiso
 coupure WiFi, l'ancienne socket reste souvent ouverte côté renderer, et sans cette règle le device serait
 incapable de se reconnecter.
 
+## Comment il obtient son token
+
+Un token n'est affiché qu'une fois, à l'appairage, et seule son empreinte est conservée
+([ADR-0012](adr/0012-format-des-tokens.md)) : le dashboard ne peut pas le redonner, il ne l'a plus. Le faire
+ressaisir reviendrait à demander à l'utilisateur d'avoir archivé à la main le credential d'une page de debug
+qu'il ouvre depuis une session déjà authentifiée.
+
+Le dashboard **fait donc tourner le credential** du device simulateur à l'ouverture, et remet le secret frais à
+la page ([ADR-0021](adr/0021-credential-du-simulateur-par-rotation.md)) :
+
+1. `POST /api/v1/devices/:id/credential` — refusé si le device n'appartient pas à l'utilisateur, et refusé aussi
+   si son renderer est hors ligne : le secret frais ne pourrait pas l'atteindre, et l'ancien serait détruit pour
+   rien.
+2. Adonis pousse `device.credential_rotated` au renderer, **puis** rend le token à la page.
+3. La page enchaîne le bootstrap et le `DEVICE_HELLO` habituels, sans rien de spécifique au navigateur.
+
+Le secret reste **en mémoire** dans l'onglet, jamais en `localStorage` : un nouveau est à un clic, le persister
+n'apporterait qu'une exposition.
+
+Deux effets à connaître. Ouvrir le simulateur **invalide l'onglet précédent** sur ce device, dont le token vient
+de mourir. Et le `token_prefix` change à chaque ouverture : il n'identifie donc pas ce device dans les journaux,
+c'est l'`id` qui le fait.
+
+Si le renderer n'a pas encore appliqué la rotation quand la page se présente, le handshake échoue en
+`ERROR 0x04` et le simulateur réessaie quelques fois. Dans cette fenêtre, et dans elle seule, un refus
+d'authentification est transitoire par construction.
+
 ## Attendus fonctionnels
 
-- Sélection d'un device `kind = simulator` parmi ceux de l'utilisateur, et saisie de son token.
+- Sélection d'un device `kind = simulator` parmi ceux de l'utilisateur. **Aucun token à saisir** : il est
+  obtenu par rotation à l'ouverture.
 - Connexion, affichage de la phase de handshake et des erreurs reçues.
 - Rendu des frames sur un canvas, avec zoom — un pixel de dalle occupe plusieurs pixels d'écran.
 - Affichage des compteurs : FPS reçues, dernière séquence, part de `FULL` et de `DELTA`, octets reçus.

--- a/docs/adr/0001-streaming-de-frames.md
+++ b/docs/adr/0001-streaming-de-frames.md
@@ -19,7 +19,7 @@ Deux modèles de diffusion s'opposaient donc :
 l'écrire sur la dalle.
 
 La cadence **visée est 30 FPS**, et c'est la valeur par défaut — mais elle est un **réglage par device**, pas une
-constante du protocole : `devices.targetFps`, entre **1 et 60**. Le renderer la reçoit dans `sync.full`
+constante du protocole : entre **1 et 60**. Le renderer la reçoit dans `sync.full`
 ([PROTOCOL-CONTROL.md](../PROTOCOL-CONTROL.md)) et l'impose au device dans `CONFIG`, qui peut être renvoyé à tout
 moment pour la modifier sans rouvrir la connexion ([PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md#0x04--config)).
 
@@ -45,7 +45,7 @@ un seul parseur. Elle a été écartée au profit du streaming simple, plus dire
   proportionnel. Un contenu qui change lentement — une horloge, une donnée relevée à la minute — n'a aucune
   raison d'être servi à 30 FPS. La borne haute à 60 laisse une marge, sans promettre une cadence que le matériel
   de référence n'a jamais démontrée ([HARDWARE.md](../HARDWARE.md)).
-- La cadence est un réglage, donc une valeur à valider et à borner côté plateforme. Un `targetFps` non borné
+- La cadence est un réglage, donc une valeur à valider et à borner côté plateforme. Une cadence non bornée
   transmis à un device est un moyen de le saturer.
 - Un mode différentiel est nécessaire pour rendre ce coût acceptable — voir
   [PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md).

--- a/docs/adr/0001-streaming-de-frames.md
+++ b/docs/adr/0001-streaming-de-frames.md
@@ -21,7 +21,7 @@ l'écrire sur la dalle.
 La cadence **visée est 30 FPS**, et c'est la valeur par défaut — mais elle est un **réglage par device**, pas une
 constante du protocole : entre **1 et 60**. Le renderer la reçoit dans `sync.full`
 ([PROTOCOL-CONTROL.md](../PROTOCOL-CONTROL.md)) et l'impose au device dans `CONFIG`, qui peut être renvoyé à tout
-moment pour la modifier sans rouvrir la connexion ([PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md#0x04--config)).
+moment pour la modifier sans rouvrir la connexion ([PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md#0x02--config)).
 
 Le choix du streaming ne dépend pas du chiffre : ce qui l'oppose au clip pré-rendu, c'est que le contenu d'une
 frame soit décidé à l'instant où elle part, pas la fréquence à laquelle elle part.

--- a/docs/adr/0001-streaming-de-frames.md
+++ b/docs/adr/0001-streaming-de-frames.md
@@ -15,8 +15,16 @@ Deux modèles de diffusion s'opposaient donc :
 
 ## Décision
 
-**Streaming de frames binaires à 30 FPS.** Le renderer calcule chaque frame et l'envoie au device, qui se
-contente de l'écrire sur la dalle.
+**Streaming de frames binaires.** Le renderer calcule chaque frame et l'envoie au device, qui se contente de
+l'écrire sur la dalle.
+
+La cadence **visée est 30 FPS**, et c'est la valeur par défaut — mais elle est un **réglage par device**, pas une
+constante du protocole : `devices.targetFps`, entre **1 et 60**. Le renderer la reçoit dans `sync.full`
+([PROTOCOL-CONTROL.md](../PROTOCOL-CONTROL.md)) et l'impose au device dans `CONFIG`, qui peut être renvoyé à tout
+moment pour la modifier sans rouvrir la connexion ([PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md#0x04--config)).
+
+Le choix du streaming ne dépend pas du chiffre : ce qui l'oppose au clip pré-rendu, c'est que le contenu d'une
+frame soit décidé à l'instant où elle part, pas la fréquence à laquelle elle part.
 
 ## Alternative écartée
 
@@ -31,8 +39,14 @@ un seul parseur. Elle a été écartée au profit du streaming simple, plus dire
 
 ## Conséquences
 
-- La bande passante devient une contrainte de conception permanente : ~185 KB/s par matrice 64×32 à 30 FPS.
+- La bande passante devient une contrainte de conception permanente : ~185 kB/s par device 64×32 à 30 FPS.
   Voir [PERFORMANCE.md](../PERFORMANCE.md).
+- **Baisser la cadence est le premier levier disponible** quand ce coût ne passe pas : le débit lui est
+  proportionnel. Un contenu qui change lentement — une horloge, une donnée relevée à la minute — n'a aucune
+  raison d'être servi à 30 FPS. La borne haute à 60 laisse une marge, sans promettre une cadence que le matériel
+  de référence n'a jamais démontrée ([HARDWARE.md](../HARDWARE.md)).
+- La cadence est un réglage, donc une valeur à valider et à borner côté plateforme. Un `targetFps` non borné
+  transmis à un device est un moyen de le saturer.
 - Un mode différentiel est nécessaire pour rendre ce coût acceptable — voir
   [PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md).
 - **Le device n'affiche plus rien si son renderer est injoignable.** C'est le prix assumé de cette décision, et

--- a/docs/adr/0002-renderer-en-go.md
+++ b/docs/adr/0002-renderer-en-go.md
@@ -13,11 +13,39 @@ La V1 rendait en TypeScript (canvas + décodage GIF + ffmpeg), à l'intérieur d
 
 **Le renderer est un programme Go autonome**, déployé séparément de l'API.
 
+Ce qui motive ce choix est la **performance** — deux propriétés précises, que le runtime de Node ne donne pas.
+
+**Le rendu est un travail CPU parallèle par nature.** Chaque device a sa boucle, sa scène et son tampon de frame
+précédente pour le calcul du DELTA. Ces boucles ne partagent rien et doivent s'exécuter en même temps. Go y
+répond par une goroutine par device, que son ordonnanceur distribue sur tous les cœurs sans qu'on ait à s'en
+occuper. Node n'exécute qu'un fil : y paralléliser suppose un pool de `worker_threads` et le transfert de
+tampons entre eux, c'est-à-dire réimplémenter à la main ce que le runtime Go fournit.
+
+**L'ordre de grandeur**, dérivé des budgets de [PERFORMANCE.md](../PERFORMANCE.md) : 10 ms de calcul plus 3 ms de
+diff et de sérialisation font 13 ms de CPU par frame et par device, soit **390 ms par seconde à 30 FPS**. Un cœur
+en sature deux ou trois. Un renderer monothreadé plafonnerait donc autour de trois devices quel que soit le
+matériel sous lui — et c'est le cas favorable, celui où rien d'autre ne tourne sur ce fil. Ces budgets sont des
+objectifs et non des mesures, mais le rapport qu'ils décrivent ne dépend pas de leur exactitude.
+
+**Ce qui casse une animation, c'est la variance, pas la moyenne.** [ADR-0001](0001-streaming-de-frames.md) fait
+du device un simple tampon : il affiche ce qui arrive, quand ça arrive, et une frame en retard se voit
+immédiatement. Or le calcul d'une frame est un bloc synchrone qu'on ne peut pas découper : sur une boucle
+d'événements partagée, une frame lente sur un device retarde tous les autres, et une pause du ramasse-miettes
+les retarde tous ensemble. L'ordonnanceur de Go préempte les goroutines et son GC est concurrent, ce qui
+contient ces deux effets au lieu de les propager à l'ensemble des devices servis.
+
+**Aucune mesure comparative n'a été faite.** Ce choix repose sur des propriétés de runtime, pas sur un
+benchmark, et il est pris avant que la première frame ait été rendue. Il est réversible : le contrat du plan de
+contrôle étant explicite ([ADR-0007](0007-plan-de-controle-wss.md)), le renderer se remplace sans toucher au
+reste de la plateforme. Une mesure montrant que TypeScript tient la charge visée est un motif suffisant pour
+rouvrir cet ADR.
+
 ## Alternatives écartées
 
 **Package ou service TypeScript dans le monorepo.** Un seul langage, types partagés avec le reste de la
-plateforme, un seul déploiement, et un précédent qui fonctionnait en V1. Écarté au profit d'une boucle de rendu
-à latence prédictible, hors du ramasse-miettes et de la boucle d'événements de Node.
+plateforme, un seul déploiement, et un précédent qui fonctionnait en V1 — mais cette V1 servait un clip
+pré-rendu, pas N boucles de rendu concurrentes : elle ne démontre rien sur la charge visée ici. Écarté pour les
+raisons ci-dessus.
 
 Il faut reconnaître le coût de ce choix : un second langage, un second pipeline de build, et une frontière de
 types que Tuyau ne couvre pas. C'est ce qui rend le contrat du plan de contrôle
@@ -29,4 +57,7 @@ garanti par le compilateur.
 - Le renderer est un **artefact déployable indépendamment**, ce qui est la condition pour qu'un utilisateur
   puisse en héberger un lui-même ([ADR-0008](0008-renderer-autonome.md)).
 - Le contrat entre Adonis et le renderer doit être documenté et versionné à la main.
+- **La capacité d'un renderer se raisonne en cœurs.** Ajouter des devices consomme du CPU parallèle ; la montée
+  en charge se fait d'abord en cœurs sur un renderer, puis en ajoutant des renderers. Ni l'un ni l'autre
+  n'impose de changement de code.
 - Un binaire Go statique se distribue sans runtime, ce qui simplifie l'auto-hébergement.

--- a/docs/adr/0002-renderer-en-go.md
+++ b/docs/adr/0002-renderer-en-go.md
@@ -60,4 +60,7 @@ garanti par le compilateur.
 - **La capacité d'un renderer se raisonne en cœurs.** Ajouter des devices consomme du CPU parallèle ; la montée
   en charge se fait d'abord en cœurs sur un renderer, puis en ajoutant des renderers. Ni l'un ni l'autre
   n'impose de changement de code.
+- Le « par device » de cet ADR est le **pire cas** : N devices affichant N scènes distinctes. Des devices
+  équivalents partagent leur calcul et ne comptent que pour un ([ADR-0017](0017-rendu-mutualise.md)). C'est ce
+  pire cas qui dimensionne, et c'est lui qui justifie le choix de Go.
 - Un binaire Go statique se distribue sans runtime, ce qui simplifie l'auto-hébergement.

--- a/docs/adr/0003-websocket-binaire-tcp.md
+++ b/docs/adr/0003-websocket-binaire-tcp.md
@@ -5,7 +5,7 @@
 ## Contexte
 
 Il faut acheminer ~30 frames/seconde du renderer vers chaque device. Une frame complète en 64×32 pèse
-6 154 octets, soit largement plus que la MTU Ethernet de 1 500 octets.
+6 153 octets, soit largement plus que la MTU Ethernet de 1 500 octets.
 
 ## Décision
 

--- a/docs/adr/0004-device-vers-renderer.md
+++ b/docs/adr/0004-device-vers-renderer.md
@@ -15,8 +15,8 @@ contrôle et **le seul composant qui accède à la base**.
 ## Alternatives écartées
 
 **Adonis termine la connexion device et relaie les frames.** Authentification centralisée et un seul port
-exposé. Écarté parce que Node se retrouverait dans le chemin critique à 30 FPS pour chaque device, ce qui annule
-l'intérêt d'un renderer séparé ([ADR-0002](0002-renderer-en-go.md)) et ajoute un saut réseau.
+exposé. Écarté parce que Node se retrouverait dans le chemin de rendu de chaque device, ce qui annule l'intérêt
+d'un renderer séparé ([ADR-0002](0002-renderer-en-go.md)) et ajoute un saut réseau.
 
 **Le renderer lit directement la base.** Aucune synchronisation à spécifier. Écarté parce que deux services
 écriraient le même schéma dans deux langages sans migrations partagées — couplage fort et dérive garantie. Cette
@@ -26,7 +26,7 @@ utilisateurs.
 
 ## Conséquences
 
-- Adonis n'est jamais dans le chemin 30 FPS.
+- Adonis n'est jamais dans le chemin de rendu.
 - Un seul propriétaire du schéma, donc un seul jeu de migrations.
 - Le renderer a besoin d'un moyen de valider les tokens device sans accès à la base : c'est le rôle du plan de
   contrôle ([ADR-0007](0007-plan-de-controle-wss.md)).

--- a/docs/adr/0006-modele-renderer-device-scene.md
+++ b/docs/adr/0006-modele-renderer-device-scene.md
@@ -15,7 +15,10 @@ Le mot « matrix » désignait donc, selon la phrase, la dalle physique, l'appar
 
 - `Renderer` — un moteur de rendu, celui de la plateforme ou celui d'un utilisateur.
 - `Device` — un appareil physique : identité, credential, géométrie, état.
-- `Scene` — un contenu : configuration versionnée et validée.
+- `Scene` — un contenu : configuration versionnée et validée, écrite pour une géométrie donnée
+  ([ADR-0018](0018-geometrie-native-de-la-scene.md)). Elle en porte une parce que son contenu est en pixels,
+  pas parce qu'elle appartiendrait à une dalle : elle reste réutilisable sur toutes celles dont la géométrie
+  en est un multiple entier.
 
 ## Alternatives écartées
 

--- a/docs/adr/0008-renderer-autonome.md
+++ b/docs/adr/0008-renderer-autonome.md
@@ -39,4 +39,11 @@ le délai de révocation devient un problème.
   le renderer reçoit l'empreinte et hache le token qu'on lui présente.
 - **La révocation n'est pas instantanée.** Il faut spécifier un événement de révocation sur le canal de
   contrôle, une durée de validité des entrées en cache, et le comportement quand le renderer est hors ligne.
-- Le renderer a besoin d'un stockage local persistant.
+- **Le renderer a besoin d'un stockage local persistant, et c'est le redémarrage qui l'impose, pas la panne.**
+  Tant que le process tourne, un cache en mémoire traverse très bien une coupure. Un renderer qui redémarre
+  pendant que la plateforme est injoignable, lui, revient sans rien : il ne connaît plus aucune empreinte,
+  refuse donc tous ses devices ([SELF-HOSTING.md](../SELF-HOSTING.md)) et éteint précisément les dalles que cet
+  ADR promet de garder allumées. Doivent survivre au redémarrage les empreintes et préfixes des devices
+  assignés, le dernier état des scènes, et **l'horodatage du dernier contact de contrôle réussi** — sans ce
+  dernier, redémarrer remettrait le compteur du bail à zéro et rendrait la borne de
+  [ADR-0015](0015-bail-de-session-device.md) contournable.

--- a/docs/adr/0008-renderer-autonome.md
+++ b/docs/adr/0008-renderer-autonome.md
@@ -31,6 +31,10 @@ le délai de révocation devient un problème.
 
 - La dalle du salon continue de fonctionner si un service distant tombe. C'est l'argument central de
   l'auto-hébergement, et il compense la fragilité introduite par [ADR-0001](0001-streaming-de-frames.md).
+- **« Dernier état connu » ne dit rien des valeurs affichées.** Ce que devient une donnée externe pendant une
+  panne dépend de qui va la chercher — question ouverte, instruite par
+  [ADR-0014](0014-sources-de-donnees-cote-adonis.md), encore `Proposé`. Quelle qu'en soit l'issue, cet ADR-ci
+  garantit qu'une dalle reste **allumée** pendant une panne, pas que ce qu'elle affiche reste **vrai**.
 - **Les empreintes de tokens device sont répliquées chez un tiers.** D'où le stockage haché, jamais en clair :
   le renderer reçoit l'empreinte et hache le token qu'on lui présente.
 - **La révocation n'est pas instantanée.** Il faut spécifier un événement de révocation sur le canal de

--- a/docs/adr/0011-auth-premier-message.md
+++ b/docs/adr/0011-auth-premier-message.md
@@ -38,5 +38,7 @@ implémentation de référence fidèle.
   laisser des sockets non authentifiées ouvertes.
 - Le simulateur reste une implémentation de référence fidèle du protocole
   ([SIMULATOR.md](../SIMULATOR.md)).
-- Corollaire à spécifier : **une seule connexion active par device**. Simulateur et matériel peuvent revendiquer
-  le même device, et après une coupure WiFi l'ancienne socket est souvent encore ouverte côté renderer.
+- Corollaire à spécifier : **une seule connexion active par device**. Après une coupure WiFi, l'ancienne socket
+  reste souvent ouverte côté renderer, et sans cette règle le device ne pourrait pas se reconnecter. Cette
+  conséquence invoquait aussi la concurrence entre simulateur et matériel sur un même device ;
+  [ADR-0020](0020-simulateur-device-declare.md) l'a fait disparaître en donnant au simulateur son propre device.

--- a/docs/adr/0014-sources-de-donnees-cote-adonis.md
+++ b/docs/adr/0014-sources-de-donnees-cote-adonis.md
@@ -1,0 +1,81 @@
+# ADR-0014 — Les sources de données appartiennent à Adonis
+
+**Statut** : Proposé — 2026-08-31
+
+> En discussion, non appliqué. Le reste de la documentation ne s'y conforme pas encore. Avant acceptation :
+> confirmer que les sources se poussent bien sur le plan de contrôle plutôt que par un canal dédié, et vérifier
+> sur une première source réelle que le modèle « nom, valeur, validité » suffit.
+
+## Contexte
+
+Une scène affiche rarement du contenu figé : l'heure, une température, un nombre de mails non lus, un cours, un
+prochain passage de bus. Ces valeurs viennent de l'extérieur du système, et il faut décider **qui va les
+chercher**.
+
+La question s'est posée en relisant [ADR-0008](0008-renderer-autonome.md) : « le renderer reste autonome sur son
+dernier état connu » ne veut rien dire tant qu'on n'a pas dit de quel état on parle. Tant que les sources ne sont
+pas modélisées, l'autonomie du renderer est une promesse sans contenu.
+
+L'heure est le cas qui force la décision, parce qu'elle est la seule source qu'un renderer pourrait produire
+seul : il a une horloge système. La traiter à part était tentant.
+
+## Décision
+
+**Toutes les valeurs affichées viennent d'Adonis, par un mécanisme unique. L'heure n'y fait pas exception.**
+
+- Une **source** a un nom, une valeur, et une durée de validité.
+- Une scène **se lie** à des sources nommées. Elle ne sait pas d'où vient une valeur.
+- Adonis récupère ou calcule les valeurs et les pousse sur le plan de contrôle
+  ([ADR-0007](0007-plan-de-controle-wss.md)).
+- Le renderer les met en cache et **rend une fonction pure de `(scène, valeurs)`**. Il ne connecte rien, ne
+  calcule aucune valeur, et n'interprète aucune source en particulier.
+
+**Entre deux poussées, une valeur ne bouge pas.** Le renderer n'extrapole rien : il affiche la dernière valeur
+reçue. Une horloge dont la valeur n'est plus rafraîchie affiche une heure figée.
+
+La répartition est donc : **Adonis possède la donnée, le renderer possède le mouvement.** Les transitions, le
+défilement et les animations restent locales et rendues à la cadence du device — c'est ce qui continue de
+justifier [ADR-0002](0002-renderer-en-go.md). Aucune valeur ne transite à la cadence de rendu.
+
+## Alternatives écartées
+
+**Le renderer récupère les sources lui-même.** Il a Internet, et une panne de la plateforme ne périmerait alors
+plus rien : l'autonomie promise par [ADR-0008](0008-renderer-autonome.md) serait entière. Écarté parce qu'un
+renderer auto-hébergé tourne chez un tiers : lui confier les sources reviendrait à lui répliquer les
+identifiants des comptes de l'utilisateur — clé d'API du service de mail, jeton du calendrier. C'est exactement
+ce que le projet refuse déjà pour les tokens device, qui ne sont répliqués que sous forme d'empreintes
+([ADR-0012](0012-format-des-tokens.md)). Il faudrait en plus un connecteur par service dans chaque renderer, et
+donc une compatibilité de connecteurs à négocier en plus des primitives de rendu.
+
+**Traiter l'heure comme un cas local.** Le renderer a une horloge système ; il pourrait rendre une horloge sans
+rien recevoir, et une panne de la plateforme n'y changerait rien. Écarté au nom de l'uniformité : une exception
+impose un second chemin de donnée à spécifier, une base de fuseaux horaires et une configuration de locale
+embarquées dans le renderer, et deux comportements différents à expliquer selon la source. Le fuseau, le format
+et la locale vivent une seule fois, à côté des préférences de l'utilisateur.
+
+**Pousser une loi d'évolution avec la valeur** — pour l'heure, un instant de référence et un fuseau, que le
+renderer prolonge avec son horloge monotone. Ce n'est pas une exception mais une généralisation : un compteur,
+une progression, un compte à rebours en bénéficieraient aussi, et l'horloge redeviendrait autonome. Écarté
+**pour l'instant** : c'est un concept de plus dans un modèle de sources qui n'a pas encore servi. C'est la piste
+naturelle une fois le produit fonctionnel, et le jour où le gel de l'heure devient gênant en pratique.
+
+## Conséquences
+
+- **L'horloge devient la scène la moins autonome.** Une panne de la plateforme la fige en une minute, et une
+  heure figée est la donnée la plus visiblement fausse qu'une dalle puisse afficher — tout le monde dans la
+  pièce en connaît la vraie valeur. C'est le coût assumé de l'uniformité, et il porte précisément sur l'exemple
+  qui motivait [ADR-0008](0008-renderer-autonome.md).
+- **L'autonomie du renderer cesse d'être une propriété déclarée pour devenir une conséquence.** Un renderer
+  reste utile aussi longtemps que les valeurs de son cache restent valides : indéfiniment pour une scène sans
+  source, une minute pour une horloge. [ADR-0008](0008-renderer-autonome.md) garantit qu'il continue de
+  **tourner** ; il ne garantit pas que ce qu'il affiche reste **vrai**.
+- **Adonis entre dans un chemin périodique**, sans entrer dans le chemin de rendu. Une horloge à la minute, c'est
+  une poussée par minute et par device sur le plan de contrôle — négligeable en regard des 30 frames par seconde
+  du plan de données, mais le plan de contrôle cesse d'être purement événementiel.
+- Les identifiants des services tiers ne quittent jamais la plateforme.
+- **Reste à spécifier** : le message de poussée des valeurs sur le plan de contrôle
+  ([PROTOCOL-CONTROL.md](../PROTOCOL-CONTROL.md), issue #27), la syntaxe de liaison dans la configuration de
+  scène, et le catalogue des sources. Cet ADR fixe la propriété et la forme, pas le vocabulaire — comme
+  `scene_nodes`, il se remplira au fil des sources ajoutées.
+- Ce qu'affiche le renderer quand une valeur a dépassé sa validité — la laisser figée, la marquer, basculer sur
+  un repli — n'est pas tranché ici. Aujourd'hui elle reste affichée telle quelle.

--- a/docs/adr/0015-bail-de-session-device.md
+++ b/docs/adr/0015-bail-de-session-device.md
@@ -28,8 +28,8 @@ plateforme** — pas par réception d'une révocation.
 - `devices.offlineGrace` : durée pendant laquelle le renderer peut servir ce device sans confirmation de la
   plateforme. Défaut **7 jours**, `null` = illimité.
 - Le renderer horodate son **dernier contact de contrôle réussi**. Tout device dont l'`offlineGrace` est dépassé
-  depuis cet horodatage voit sa connexion fermée avec `ERROR 0x09`. Une seule horloge, un seuil par device.
-- L'entrée n'est pas purgée mais **marquée expirée** : les reconnexions sont refusées avec `0x09` et non `0x04`,
+  depuis cet horodatage voit sa connexion fermée avec `ERROR 0x0A`. Une seule horloge, un seuil par device.
+- L'entrée n'est pas purgée mais **marquée expirée** : les reconnexions sont refusées avec `0x0A` et non `0x04`,
   ce qui distingue « ton token est invalide » de « le renderer a perdu la plateforme ». La différence compte le
   jour où il faut diagnostiquer une dalle noire.
 - Un contact réussi avec Adonis réarme tous les baux.
@@ -66,7 +66,7 @@ pour la raison inchangée qu'une panne de la plateforme éteindrait toutes les d
   renderer auto-hébergé, qui est derrière NAT et ne sert que son réseau local
   ([ADR-0007](0007-plan-de-controle-wss.md)) ; et le renderer de la plateforme étant colocalisé avec Adonis,
   `device.revoked` y parvient sans délai notable.
-- Le firmware doit traiter `0x09` autrement qu'un refus d'authentification : il s'agit d'un état transitoire,
+- Le firmware doit traiter `0x0A` autrement qu'un refus d'authentification : il s'agit d'un état transitoire,
   qui se résout quand le renderer retrouve la plateforme. Retrait exponentiel, pas d'abandon définitif.
 - Un `offlineGrace` à `null` restaure exactement le comportement antérieur, pour les dalles où l'autonomie prime
   sur la révocation.

--- a/docs/adr/0015-bail-de-session-device.md
+++ b/docs/adr/0015-bail-de-session-device.md
@@ -70,6 +70,8 @@ pour la raison inchangée qu'une panne de la plateforme éteindrait toutes les d
   qui se résout quand le renderer retrouve la plateforme. Retrait exponentiel, pas d'abandon définitif.
 - Un `offlineGrace` à `null` restaure exactement le comportement antérieur, pour les dalles où l'autonomie prime
   sur la révocation.
-- **Piste non traitée.** La règle `ERROR 0x08` rend un vol de token bruyant : l'imposteur et la dalle légitime
-  s'évincent mutuellement en boucle, et Adonis voit le `device.status` battre. C'est un signal de détection
-  gratuit, en amont de la révocation — il dit *quand* révoquer. Rien ne l'exploite aujourd'hui.
+- **Un signal de détection gratuit.** La règle `ERROR 0x08` rend un vol de token bruyant : l'imposteur et la
+  dalle légitime s'évincent mutuellement en boucle, et Adonis voit le `device.status` battre. C'est une
+  détection en amont de la révocation — elle dit *quand* révoquer. Rien ne l'exploite encore ; l'exploitation
+  est suivie par l'issue [#57](https://github.com/smyllet/matrixled-ssr/issues/57), et la réponse est la
+  rotation du credential ([ADR-0021](0021-credential-du-simulateur-par-rotation.md)).

--- a/docs/adr/0015-bail-de-session-device.md
+++ b/docs/adr/0015-bail-de-session-device.md
@@ -1,0 +1,75 @@
+# ADR-0015 — Bail de session device, borné par l'absence de contact
+
+**Statut** : Accepté — 2026-08-31
+
+## Contexte
+
+[ADR-0008](0008-renderer-autonome.md) rend le renderer autonome sur son cache et accepte en contrepartie que la
+révocation ne soit pas instantanée. [PROTOCOL-CONTROL.md](../PROTOCOL-CONTROL.md) bornait cette fenêtre par trois
+mécanismes, dont une durée de validité des entrées en cache.
+
+**Cette borne ne fonctionnait pas.** Telle qu'elle était spécifiée, l'expiration refusait les nouvelles
+connexions du device concerné « mais ne coupait pas celles déjà établies ». Or
+[ADR-0001](0001-streaming-de-frames.md) fait du lien renderer → device une connexion **permanente** : un device
+connecté reçoit ses frames en continu et ne se réauthentifie jamais. L'expiration ne s'appliquait donc qu'aux
+reconnexions, c'est-à-dire à tout sauf à une dalle allumée — la seule population qu'il s'agissait de borner.
+
+Le cas qui le rend visible n'est pas le vol franc mais le **token fuité** chez quelqu'un qui garde l'accès au
+réseau : dalle prêtée, colocataire, ancien employé. La règle « une seule connexion active par device »
+([PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md)) lui permet d'évincer la dalle légitime et de prendre sa place. Sur
+un renderer coupé de la plateforme, il y restait indéfiniment : la révocation ne peut pas arriver, et
+l'expiration ne coupait rien.
+
+## Décision
+
+**Le droit d'un device à recevoir des frames est un bail, et ce bail expire par absence de contact avec la
+plateforme** — pas par réception d'une révocation.
+
+- `devices.offlineGrace` : durée pendant laquelle le renderer peut servir ce device sans confirmation de la
+  plateforme. Défaut **7 jours**, `null` = illimité.
+- Le renderer horodate son **dernier contact de contrôle réussi**. Tout device dont l'`offlineGrace` est dépassé
+  depuis cet horodatage voit sa connexion fermée avec `ERROR 0x09`. Une seule horloge, un seuil par device.
+- L'entrée n'est pas purgée mais **marquée expirée** : les reconnexions sont refusées avec `0x09` et non `0x04`,
+  ce qui distingue « ton token est invalide » de « le renderer a perdu la plateforme ». La différence compte le
+  jour où il faut diagnostiquer une dalle noire.
+- Un contact réussi avec Adonis réarme tous les baux.
+
+Le renversement est là : **le déclencheur devient l'absence de contact.** Un message de révocation ne peut par
+définition pas traverser un canal coupé ; seule l'absence de nouvelles est observable des deux côtés.
+
+## Alternatives écartées
+
+**Un bail sur le renderer entier**, comme envisagé dans [ADR-0008](0008-renderer-autonome.md). Un seul délai, un
+seul compteur, plus simple à spécifier. Écarté parce qu'il éteint tout en bloc : la panne couperait l'horloge du
+salon en même temps que l'écran sensible. Le curseur entre révocation rapide et autonomie longue n'est pas le
+même pour toutes les dalles, et le régler par device est précisément ce qui permet de garder
+[ADR-0008](0008-renderer-autonome.md) intact là où il compte.
+
+**Faire réauthentifier le device périodiquement.** L'expiration s'appliquerait alors naturellement, sans rien
+changer au modèle. Écarté parce qu'il faudrait soit couper le flux à chaque cycle, soit spécifier un handshake
+en cours de session — et parce que ça déplace le coût sur le firmware alors que le renderer dispose déjà de
+toute l'information nécessaire pour décider seul.
+
+**Déléguer la validation à Adonis** à chaque connexion : déjà écarté par [ADR-0008](0008-renderer-autonome.md),
+pour la raison inchangée qu'une panne de la plateforme éteindrait toutes les dalles.
+
+## Conséquences
+
+- La fenêtre d'exposition devient **finie et réglable par dalle**, au lieu d'être infinie. C'est le curseur que
+  l'utilisateur règle : court sur un écran qui affiche des données sensibles, `null` sur l'horloge du salon.
+- **[SELF-HOSTING.md](../SELF-HOSTING.md) change de promesse.** « Ne jamais éteindre ses dalles parce que la
+  plateforme ne répond plus » devient « jamais du seul fait d'une panne, mais oui quand un bail expire ». Le
+  défaut de 7 jours fait qu'aucune panne réaliste n'éteint quoi que ce soit.
+- **Portée à ne pas surestimer.** Ce mécanisme protège contre la panne, l'accident et le token fuité. Il ne
+  protège pas contre un opérateur de renderer hostile — il a la machine et peut patcher le binaire. Et il n'a
+  pas à couvrir le vol franc, déjà traité par la topologie : une dalle volée et emportée ne joint plus un
+  renderer auto-hébergé, qui est derrière NAT et ne sert que son réseau local
+  ([ADR-0007](0007-plan-de-controle-wss.md)) ; et le renderer de la plateforme étant colocalisé avec Adonis,
+  `device.revoked` y parvient sans délai notable.
+- Le firmware doit traiter `0x09` autrement qu'un refus d'authentification : il s'agit d'un état transitoire,
+  qui se résout quand le renderer retrouve la plateforme. Retrait exponentiel, pas d'abandon définitif.
+- Un `offlineGrace` à `null` restaure exactement le comportement antérieur, pour les dalles où l'autonomie prime
+  sur la révocation.
+- **Piste non traitée.** La règle `ERROR 0x08` rend un vol de token bruyant : l'imposteur et la dalle légitime
+  s'évincent mutuellement en boucle, et Adonis voit le `device.status` battre. C'est un signal de détection
+  gratuit, en amont de la révocation — il dit *quand* révoquer. Rien ne l'exploite aujourd'hui.

--- a/docs/adr/0016-transports-declares-par-le-renderer.md
+++ b/docs/adr/0016-transports-declares-par-le-renderer.md
@@ -1,0 +1,74 @@
+# ADR-0016 — Le renderer déclare ses transports
+
+**Statut** : Accepté — 2026-08-31
+
+## Contexte
+
+[PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md) annonçait une `renderer_url` en `wss://`, sans jamais dire comment
+un renderer auto-hébergé l'obtient. Or il est derrière NAT, sur une adresse de réseau local
+([ADR-0007](0007-plan-de-controle-wss.md)) : aucune autorité publique ne lui délivrera de certificat pour
+`192.168.1.50`.
+
+La réponse implicite était « certificat auto-signé ». Elle ne tient pas : un device qui accepte un certificat
+auto-signé sans l'épingler obtient du **chiffrement sans authentification**. N'importe qui sur le réseau local
+peut se placer au milieu et capter le token, qui passe en premier message
+([ADR-0011](0011-auth-premier-message.md)). Le `wss://` était donc décoratif dans ce cas précis.
+
+Le simulateur a rendu le problème visible. Étant une page du dashboard
+([ARCHITECTURE.md](../ARCHITECTURE.md)), il est soumis aux règles du navigateur : une page servie en HTTPS ne
+peut pas ouvrir un `ws://`, ni un `wss://` dont le certificat n'est pas reconnu. Là où un firmware peut ignorer
+une validation, un navigateur refuse — conformément à la règle de conception de
+[SIMULATOR.md](../SIMULATOR.md), qui veut que le simulateur révèle ce que le protocole suppose sans le dire.
+
+## Décision
+
+**Le renderer déclare les transports sur lesquels il est joignable, et le client choisit.**
+
+- `renderer.hello` porte `endpoints`, une liste d'adresses au lieu d'une adresse unique. Un renderer peut
+  n'annoncer que `wss://`, que `ws://`, ou les deux.
+- Le bootstrap renvoie cette liste telle quelle. **Le choix appartient au client**, pas à Adonis :
+  - un firmware retient `wss://` s'il est présent, `ws://` sinon ;
+  - le simulateur ne retient que les schémas que le navigateur autorise **depuis l'origine de la page qui le
+    sert** : servi en HTTPS il ne garde que `wss://`, servi en HTTP il accepte les deux.
+
+Le critère est le schéma de la page, et non celui de la plateforme. C'est la même règle, correctement évaluée,
+et elle rattrape gratuitement le cas qui compte le plus : en développement le dashboard est servi sur
+`http://localhost:3000`, donc le simulateur y atteint un renderer en `ws://` sur le réseau local. Le seul cas
+réellement contraint est le dashboard hébergé en HTTPS.
+
+Renvoyer la liste entière plutôt qu'une adresse choisie par Adonis préserve une propriété qui a un prix :
+**simulateur et firmware continuent d'emprunter exactement le même bootstrap.** Une réponse qui varierait selon
+l'appelant ferait du simulateur un client à part, donc un instrument de vérification qui ne vérifie plus la
+bonne chose.
+
+`ws://` en clair sur un réseau local est **assumé** : c'est ce que l'auto-signé offrait déjà en pratique, sans
+le prétendre.
+
+## Alternatives écartées
+
+**Épingler l'empreinte du certificat**, livrée au bootstrap à côté de l'adresse. Le firmware obtiendrait une
+authentification réelle pour quelques lignes de spécification, et c'est strictement meilleur que l'auto-signé
+non vérifié. Écarté **pour l'instant** seulement : ça ne débloque pas le navigateur, qui ne sait pas épingler, et
+ça reste cumulable avec la présente décision le jour où le lien local doit être durci.
+
+**Faire émettre les certificats par la plateforme** pour chaque renderer auto-hébergé, avec une zone DNS
+publique pointant vers des adresses privées. Ça fonctionne réellement et ça débloquerait le navigateur partout.
+Écarté : il faudrait faire de l'ACME pour le compte des utilisateurs, livrer des clés privées à des machines
+tierces et publier leurs adresses locales. Hors de proportion, et à contre-courant de la posture du projet sur
+les secrets répliqués ([ADR-0012](0012-format-des-tokens.md)).
+
+**Laisser Adonis choisir l'adresse selon l'appelant.** Plus simple pour les clients, qui reçoivent une chaîne.
+Écarté pour la raison ci-dessus : le simulateur cesserait d'exercer le même chemin que le matériel.
+
+## Conséquences
+
+- `Renderer.endpoint` devient `Renderer.endpoints`, une liste. C'est la seule rupture de forme.
+- **La déclaration n'est pas vérifiable.** Un renderer auto-hébergé est injoignable depuis Adonis, qui ne peut
+  donc pas sonder ce qu'il annonce — et « je sers du TLS » ne veut de toute façon pas dire « un navigateur
+  acceptera mon certificat ». C'est cohérent avec le fait que le renderer soit une entrée non fiable
+  ([SELF-HOSTING.md](../SELF-HOSTING.md)) : Adonis borne et persiste, il ne valide pas la réalité. Le mode
+  d'échec est donc un simulateur qui propose un renderer et échoue à s'y connecter ; la réponse est un message
+  d'erreur qui nomme la cause probable, pas une machinerie de sonde.
+- Le simulateur hébergé n'atteint que les renderers déclarant `wss://` avec un certificat reconnu — en pratique
+  celui de la plateforme. En développement, il les atteint tous.
+- Aucun changement au protocole binaire : seul le contenu du bootstrap et de `renderer.hello` change.

--- a/docs/adr/0017-rendu-mutualise.md
+++ b/docs/adr/0017-rendu-mutualise.md
@@ -1,0 +1,104 @@
+# ADR-0017 — Le rendu est mutualisé par groupe, pas par device
+
+**Statut** : Accepté — 2026-08-31
+
+## Contexte
+
+Le modèle lie **N devices à une scène** : `devices.sceneId` pointe vers une `scenes`, et
+[GLOSSARY.md](../GLOSSARY.md) le dit explicitement — « plusieurs devices peuvent afficher la même scène ». Le cas
+n'est pas théorique : un mur de dalles identiques, ou la même horloge dans deux pièces, sont les premiers usages
+du produit.
+
+Rien ne disait ce que le renderer devait en faire. Deux documents suggéraient même le contraire :
+
+- [PROTOCOL-CONTROL.md](../PROTOCOL-CONTROL.md) recopiait la configuration complète de la scène **dans chaque
+  entrée de device** de `sync.full`. Rien n'obligeait deux copies d'une même scène en une même version à être
+  identiques, et la forme du message présentait N contenus indépendants là où il y en avait un.
+- [ADR-0002](0002-renderer-en-go.md) raisonne « une goroutine par device » et en dérive 390 ms de CPU par
+  seconde **et par device**. Appliqué à huit dalles affichant la même chose, ce calcul compte huit fois le même
+  travail.
+
+## Décision
+
+**Le renderer calcule une frame par groupe de rendu, pas par device.** Deux devices appartiennent au même groupe
+quand ils partagent :
+
+| Clé de groupe | Pourquoi elle en fait partie |
+|---------------|------------------------------|
+| `scene_id` + `version` | Deux scènes différentes n'ont aucun pixel en commun |
+
+Depuis [ADR-0019](0019-cadence-portee-par-la-scene.md), la cadence est portée par la scène : elle est donc
+commune au groupe par construction, et la clé se réduit à la scène elle-même. **Une scène, une boucle.**
+
+La géométrie du device **n'en fait pas partie**. Une scène est évaluée à sa géométrie native, puis répliquée en
+blocs `k×k` pour chaque device ([ADR-0018](0018-geometrie-native-de-la-scene.md)) : une dalle 64×32 et une
+128×64 sur la même scène partagent donc le calcul, et ne divergent qu'à l'expansion et à l'encodage. `chainLength`
+n'y figure pas non plus — il décrit le câblage, pas l'image : deux devices de même géométrie totale reçoivent les
+mêmes octets quel que soit leur chaînage.
+
+Et **le plan de contrôle est normalisé en conséquence** : `sync.full` et `sync.delta` portent une section
+`scenes` de premier niveau, chaque device n'en portant que le `scene_id` ; `scene.updated` est émis une fois par
+scène, jamais une fois par device.
+
+### Ce que le groupe partage, et ce qu'il ne partage pas
+
+Le partage s'arrête au **tampon de pixels natif**. Tout ce qui suit reste par device :
+
+- **L'expansion `k×k`**, quand la géométrie du device est un multiple de celle de la scène.
+- **Le plafonnement d'émission** : un device à `maxFps` ne reçoit qu'une frame sur `n`
+  ([ADR-0019](0019-cadence-portee-par-la-scene.md)).
+
+- **L'en-tête de frame** — `brightness` est un champ de `FULL_FRAME`
+  ([PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md#0x01--full_frame)), donc deux devices d'un même groupe réglés à des
+  luminosités différentes émettent des octets différents à partir du même tampon.
+- **Le numéro de séquence et le tampon de frame précédente**, donc le DELTA. Il dépend de la dernière frame
+  appliquée *par ce device-là*, et diverge dès qu'un device se reconnecte — le suivant reçoit un `FULL_FRAME`
+  pendant que les autres continuent en différentiel.
+- **La connexion, la backpressure et l'état d'authentification.**
+
+Sur les budgets de [PERFORMANCE.md](../PERFORMANCE.md), le groupe mutualise les 10 ms de calcul, pas les 3 ms de
+diff et de sérialisation.
+
+### Conséquence visible : le verrouillage de phase
+
+Les devices d'un même groupe partagent une seule boucle, donc une seule horloge d'animation. Ils affichent la
+même image au même instant, au lieu de dériver selon l'heure à laquelle chacun s'est connecté. Sur un mur de
+dalles, c'est le comportement attendu ; ailleurs, c'est sans effet observable.
+
+Le partage suppose que le rendu soit une **fonction pure** de la scène, des valeurs de sources et de la phase.
+C'est exactement ce que pose [ADR-0014](0014-sources-de-donnees-cote-adonis.md) : le renderer ne va chercher
+aucune donnée de lui-même, il reçoit des valeurs.
+
+## Alternatives écartées
+
+**Une boucle par device, sans partage.** C'est ce que la formulation d'ADR-0002 laissait entendre, et c'est plus
+simple : aucun groupe à recomposer, aucune invalidation. Écarté parce que le coût est exactement multiplié par
+le nombre de dalles identiques — le cas du mur de dalles, celui où la charge est la plus forte, est aussi celui
+où le calcul est le plus redondant. Et la dérive de phase entre dalles voisines y est visible à l'œil.
+
+**Mutualiser aussi l'encodage.** Il faudrait que les devices d'un groupe soient en lockstep sur leurs frames
+appliquées, ce que rien ne garantit : une reconnexion, une backpressure ou une luminosité différente suffit à
+les désynchroniser. Le gain serait de 3 ms sur 13, au prix d'un cas particulier permanent.
+
+**Grouper sur la seule scène, en redimensionnant la frame à volonté.** Réduire un rendu 128×64 en 64×32 ne
+produit pas ce que la scène décrit, il produit du texte illisible. Seul l'agrandissement **entier** est exact, et
+c'est la limite que pose [ADR-0018](0018-geometrie-native-de-la-scene.md) — pas le refus de tout partage entre
+géométries.
+
+**Dédupliquer côté Adonis.** Hors sujet : Adonis n'a pas connaissance des frames ([ADR-0004](0004-device-vers-renderer.md)),
+et le déduplicateur doit être là où le calcul a lieu.
+
+## Conséquences
+
+- **La capacité se raisonne en groupes de rendu, pas en devices.** Huit dalles identiques coûtent un calcul et
+  huit encodages. Le raisonnement d'ADR-0002 reste valide sur son pire cas — N devices, N scènes distinctes,
+  N calculs — et c'est bien ce pire cas qui justifie le choix de Go.
+- Le renderer doit **recomposer ses groupes** à chaque `device.assigned` et `device.unassigned`, et un groupe
+  vide disparaît. Depuis [ADR-0019](0019-cadence-portee-par-la-scene.md), aucun réglage de device ne peut plus
+  faire changer un device de groupe : luminosité, géométrie et plafond n'agissent qu'après le calcul.
+- **Une primitive de scène qui dépendrait de l'identité du device** — afficher son nom, sa température —
+  casserait le partage. Le catalogue de primitives n'en prévoit aucune aujourd'hui
+  ([DATA-MODEL.md](../DATA-MODEL.md#configuration-de-scène)) ; si une telle primitive apparaît, elle doit sortir
+  le device de son groupe, et ce point est à trancher au moment de l'ajouter.
+- Le `state_version` reste unique pour tout le registre : la normalisation change la forme des messages, pas le
+  mécanisme de resynchronisation.

--- a/docs/adr/0017-rendu-mutualise.md
+++ b/docs/adr/0017-rendu-mutualise.md
@@ -48,9 +48,11 @@ Le partage s'arrête au **tampon de pixels natif**. Tout ce qui suit reste par d
 - **Le plafonnement d'émission** : un device à `maxFps` ne reçoit qu'une frame sur `n`
   ([ADR-0019](0019-cadence-portee-par-la-scene.md)).
 
-- **L'en-tête de frame** — `brightness` est un champ de `FULL_FRAME`
-  ([PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md#0x01--full_frame)), donc deux devices d'un même groupe réglés à des
-  luminosités différentes émettent des octets différents à partir du même tampon.
+- **L'en-tête de frame**, qui porte le compteur `sequence`
+  ([PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md#le-compteur-sequence)) : il appartient à la connexion d'un device,
+  donc deux devices d'un même groupe émettent des octets différents à partir du même tampon. La luminosité, elle,
+  ne voyage que dans `CONFIG` : elle n'entre dans aucune frame et n'a donc d'effet ni sur le calcul ni sur
+  l'encodage.
 - **Le numéro de séquence et le tampon de frame précédente**, donc le DELTA. Il dépend de la dernière frame
   appliquée *par ce device-là*, et diverge dès qu'un device se reconnecte — le suivant reçoit un `FULL_FRAME`
   pendant que les autres continuent en différentiel.

--- a/docs/adr/0018-geometrie-native-de-la-scene.md
+++ b/docs/adr/0018-geometrie-native-de-la-scene.md
@@ -1,0 +1,78 @@
+# ADR-0018 — La scène porte sa géométrie native, l'agrandissement est entier
+
+**Statut** : Accepté — 2026-08-31
+
+## Contexte
+
+`scenes.config` ne porte aucune géométrie. Rien ne dit donc pour quelle dalle une scène a été conçue, et deux
+conséquences en découlent :
+
+- **Une assignation absurde est acceptée.** Une scène pensée pour du 64×32 peut être assignée à une dalle 32×32,
+  où la moitié du contenu tombe hors champ.
+- **Une scène n'a pas de sens stable.** [ADR-0017](0017-rendu-mutualise.md) supposait implicitement que le
+  renderer évalue la scène à la géométrie du device. Un texte placé en (10, 4) désigne alors un endroit différent
+  sur chaque dalle, et la même scène en version 12 signifie autre chose selon qui l'affiche.
+
+Le contenu est ici en pixels, pas en points : une police 5×7 n'existe pas à 3,5 pixels de haut. À cette
+résolution, la géométrie n'est pas un paramètre de présentation, elle fait partie du contenu.
+
+## Décision
+
+**Une scène déclare la géométrie pour laquelle elle est écrite** — `scenes.width` et `scenes.height` — et elle ne
+peut être assignée qu'à un device dont la géométrie en est un **multiple entier, identique sur les deux axes** :
+
+```
+device.width  = k × scene.width
+device.height = k × scene.height       avec k entier ≥ 1
+```
+
+Le renderer évalue la scène à sa géométrie native, puis **réplique chaque pixel en un bloc k×k**. Sur une dalle
+LED ce n'est pas un redimensionnement : il n'y a ni interpolation ni flou, la frame agrandie contient exactement
+l'information de la frame native.
+
+| Scène | Device | Verdict |
+|-------|--------|---------|
+| 64×32 | 64×32 | k = 1 |
+| 64×32 | 128×64 | k = 2, réplication exacte |
+| 64×32 | 32×32 | refusé — il faudrait détruire un pixel sur deux |
+| 64×32 | 128×32 | refusé — k différent par axe, l'image serait étirée |
+| 64×32 | 96×48 | refusé — k = 1,5 doublerait un pixel sur deux et pas les autres |
+
+Les trois refus sont des **refus à l'écriture**, dans l'API : une assignation impossible ne doit pas atteindre le
+renderer, où le seul recours serait un écran noir ou une image fausse.
+
+## Alternatives écartées
+
+**Une scène sans géométrie, à coordonnées relatives.** Séduisant sur le papier — une scène s'afficherait
+partout. Écarté parce que le problème n'est pas d'échelle mais de seuil : sur 32×32 un glyphe ne devient pas
+petit, il cesse d'exister. Et des coordonnées normalisées produisent des positions non entières, c'est-à-dire
+exactement le flou qu'on ne peut pas se permettre ici. Les dalles HUB75 visées par
+[ADR-0005](0005-hub75-dabord.md) forment de toute façon un petit ensemble discret de tailles, pas un continuum.
+
+**Une géométrie libre, avec redimensionnement quelconque à l'affichage.** C'est ce que la formulation initiale
+d'ADR-0017 rejetait déjà, à raison, mais en bloc : elle interdisait aussi le cas entier, qui lui est gratuit.
+
+**k = 1 strict, aucune tolérance.** La règle la plus simple, et celle qui était implicitement en vigueur. Écartée
+parce qu'elle oblige à dupliquer une scène pour une dalle 128×64 jumelle d'une 64×32, avec une copie à maintenir
+à la main et deux versions qui divergeront.
+
+**Une scène multi-géométries, avec des variantes par taille.** C'est la vraie réponse à la qualité graphique :
+une scène 32×32 mérite une composition différente, pas une réduction. Mais c'est une fonctionnalité d'édition, et
+elle multiplierait la surface de l'éditeur avant qu'une seule primitive existe. Reportée, pas condamnée — ADR à
+rouvrir quand le catalogue de primitives sera posé.
+
+## Conséquences
+
+- **Le dashboard ne propose que les scènes compatibles** pour un device donné, plutôt que de laisser choisir puis
+  refuser. Le refus reste nécessaire côté API, l'interface n'étant pas une garantie.
+- **Changer la géométrie d'un device peut invalider son assignation.** L'API doit soit refuser le changement,
+  soit désassigner explicitement la scène — jamais laisser une paire incompatible en base.
+- **[ADR-0017](0017-rendu-mutualise.md) s'élargit** : l'évaluation ne dépendant plus de la géométrie du device,
+  une dalle 64×32 et une 128×64 sur la même scène partagent le calcul. La géométrie sort de la clé
+  d'évaluation ; elle reste dans celle de l'émission, où chaque device reçoit ses propres octets.
+- **L'agrandissement est fait par le renderer, donc payé sur le réseau.** Une dalle 128×64 servie par une scène
+  64×32 reçoit quatre fois plus d'octets que d'information — 5,90 Mbit/s au lieu de 1,48
+  ([PERFORMANCE.md](../PERFORMANCE.md)). Déplacer la réplication dans le firmware diviserait ce coût par k² sur
+  le lien le plus contraint du système, au prix d'un facteur d'échelle dans `CONFIG` et `FULL_FRAME` et de
+  l'expansion côté device. **Piste non tranchée**, à reprendre quand le firmware existera.
+- La migration depuis `matrices` est directe : la scène créée hérite de la géométrie de la matrice, k = 1.

--- a/docs/adr/0019-cadence-portee-par-la-scene.md
+++ b/docs/adr/0019-cadence-portee-par-la-scene.md
@@ -1,0 +1,83 @@
+# ADR-0019 — La cadence appartient à la scène, le device en pose le plafond
+
+**Statut** : Accepté — 2026-08-31
+
+## Contexte
+
+[ADR-0001](0001-streaming-de-frames.md) a fait de la cadence un réglage, et l'a posé sur le device :
+`devices.targetFps`. Après [ADR-0017](0017-rendu-mutualise.md) et [ADR-0018](0018-geometrie-native-de-la-scene.md),
+c'est le dernier champ qui empêche une scène d'avoir une boucle de rendu unique : deux devices affichant la même
+scène à deux cadences différentes restent deux évaluations.
+
+Or `targetFps` répondait à **deux questions distinctes** qu'il confondait :
+
+- **Ce que le contenu exige.** Une horloge à l'aiguille des minutes n'a rien à calculer trente fois par seconde ;
+  un texte défilant si. C'est une propriété de la scène, connue de son auteur.
+- **Ce que le lien supporte.** Un WiFi encombré, une dalle 128×128 à 11,8 Mbit/s
+  ([PERFORMANCE.md](../PERFORMANCE.md)), une dalle qu'on ne veut pas prioriser sur un point d'accès partagé.
+  C'est une propriété du device et de son réseau, connue de son propriétaire.
+
+Un seul champ pour les deux oblige à choisir qui décide. Sur la scène seule, l'utilisateur qui veut soulager
+**une** dalle doit dupliquer la scène — la duplication qu'ADR-0018 s'applique justement à éviter.
+
+## Décision
+
+**La cadence est portée par la scène ; le device porte un plafond facultatif.**
+
+| Champ | Entité | Rôle |
+|-------|--------|------|
+| `targetFps` | `scenes` | Cadence à laquelle la scène est évaluée. 1 à 60, défaut 30 |
+| `maxFps` | `devices` | Plafond d'émission. `null` par défaut, c'est-à-dire aucun plafond |
+
+Le renderer **évalue une fois par scène**, à `scene.targetFps`. Pour un device plafonné, il n'émet qu'une frame
+sur `n` :
+
+```
+n = ⌈ scene.targetFps / device.maxFps ⌉        (n = 1 si maxFps est null)
+cadence effective du device = scene.targetFps / n
+```
+
+**`n` est entier par construction, et ce n'est pas un détail d'implémentation.** Une scène à 30 plafonnée à 20
+émet à 15, pas à 20 : le device est un tampon qui affiche ce qui arrive au moment où ça arrive
+([ADR-0001](0001-streaming-de-frames.md)), donc une émission à intervalles inégaux — 33 ms, 33 ms, saut — se voit
+comme un à-coup. Un sous-multiple exact est régulier ; une moyenne juste ne l'est pas.
+
+La cadence effective est celle qu'Adonis calcule et transmet dans `CONFIG` : le device continue de recevoir un
+seul chiffre et n'a rien à arbitrer.
+
+## Alternatives écartées
+
+**Garder la cadence sur le device seul** — l'état actuel. Écarté parce que c'est le dernier obstacle à la boucle
+unique par scène, et parce que le réglage y est mal placé : l'auteur d'une horloge sait qu'elle n'a pas besoin de
+30 FPS, le propriétaire de la dalle ne le sait pas.
+
+**La porter sur la scène seule, sans plafond.** C'est la forme la plus simple, et elle donne la boucle unique
+aussi. Écartée parce qu'elle supprime le seul levier de bande passante par dalle qu'ADR-0001 avait explicitement
+retenu : la seule échappatoire deviendrait la duplication de scène.
+
+**Laisser la backpressure s'en charger.** Le renderer sait déjà abandonner des frames pour un device qui ne suit
+pas (« latest frame wins », [PROTOCOL-DEVICE.md](../PROTOCOL-DEVICE.md#backpressure)). Mais la backpressure ne
+voit que la socket de ce device : elle réagit à un device saturé, pas à un **réseau** encombré par autre chose,
+et elle ne réagit qu'après coup. C'est une soupape, pas un réglage. Les deux coexistent.
+
+**Un plafond au niveau du renderer** plutôt que du device. Plus proche du budget CPU, mais le facteur limitant
+ici est le lien WiFi d'une dalle donnée, pas le renderer — et un plafond global pénaliserait la dalle qui n'a pas
+de problème.
+
+## Conséquences
+
+- **La clé de groupe de [ADR-0017](0017-rendu-mutualise.md) se réduit à `scene_id` + `version`.** Une scène, une
+  boucle, quelle que soit la géométrie ou le plafond des devices qui l'affichent. Le plafonnement et
+  l'agrandissement `k×k` sont deux post-traitements par device, appliqués sur une frame déjà calculée.
+- **Le rendu est identique sur toutes les dalles d'une scène**, phase comprise. Un device plafonné voit la même
+  animation, moins souvent — jamais une animation différente.
+- `1 ≤ scenes.targetFps ≤ 60` est borné à l'écriture, comme l'exigeait déjà ADR-0001 : la valeur part telle
+  quelle vers le renderer puis vers le device, et rien en aval ne la revalide. Même borne pour `devices.maxFps`
+  quand il n'est pas `null`.
+- **Un plafond ne peut pas éteindre une dalle** : `n` est fini, la cadence effective est toujours ≥ 1 FPS dès
+  lors que `maxFps ≥ 1`.
+- La migration depuis `matrices` ne transporte aucune cadence — le champ n'existe pas dans le schéma actuel. Les
+  scènes migrées prennent le défaut de 30, les devices migrés `maxFps = null`.
+- Reste non traité, comme avant cet ADR : que fait le renderer d'un device qui **rapporte** durablement des `fps`
+  très inférieurs à sa cadence effective. Un plafond automatique déduit de la mesure serait tentant ; il
+  reviendrait à laisser un device non fiable piloter son propre réglage.

--- a/docs/adr/0020-simulateur-device-declare.md
+++ b/docs/adr/0020-simulateur-device-declare.md
@@ -1,0 +1,78 @@
+# ADR-0020 — Le simulateur est un device déclaré, pas un device emprunté
+
+**Statut** : Accepté — 2026-08-31
+
+## Contexte
+
+Deux documents décrivaient deux modèles différents.
+
+[DATA-MODEL.md](../DATA-MODEL.md) portait un champ `isSimulator` décrit comme distinguant « un simulateur dans
+l'interface » : une étiquette. [SIMULATOR.md](../SIMULATOR.md) décrivait à l'inverse un simulateur qui se
+connecte avec le token de **n'importe quel** device du registre, matériel compris, et allait jusqu'à en tirer un
+comportement voulu — « ouvrir le simulateur sur un device allumé coupe la dalle ».
+
+La contradiction n'est pas cosmétique : dans ce second modèle, le drapeau ne décrit rien que quoi que ce soit
+maintienne vrai. Un device marqué simulateur peut être revendiqué par du firmware, un device matériel peut être
+revendiqué par un onglet. Un champ que rien ne garantit est pire qu'un champ absent, parce que l'interface
+l'affiche comme s'il signifiait quelque chose.
+
+S'y ajoute une gêne d'usage : observer une dalle imposait de saisir le token d'un device de production dans une
+page de debug, et d'éteindre cette dalle pendant l'observation.
+
+## Décision
+
+**Un device déclare sa nature.** `devices.kind` vaut `hardware` ou `simulator`, est choisi à la création et
+n'est plus modifiable ensuite.
+
+- Le simulateur ne propose que les devices `kind = simulator`. Observer une scène consiste à créer un device
+  simulateur et à lui assigner cette scène, pas à emprunter l'identité d'une dalle.
+- **Le renderer n'en sait rien.** `kind` ne voyage pas sur le plan de contrôle et n'apparaît pas dans le
+  protocole device. C'est déjà ce qu'exige [SIMULATOR.md](../SIMULATOR.md) : aucun cas particulier côté renderer,
+  sans quoi le simulateur cesserait de vérifier ce qu'il prétend vérifier.
+
+**Ce que cette règle est, et ce qu'elle n'est pas.** C'est une règle de registre, tenue par le dashboard et
+l'API. Ce n'est pas une frontière d'authentification : rien dans `DEVICE_HELLO` ne distingue un navigateur d'un
+firmware, et le renderer ne pourrait donc pas l'appliquer même s'il le voulait. Il n'y a d'ailleurs rien à en
+protéger — les deux devices appartiennent au même utilisateur. Ce qu'on écarte est une confusion, pas un
+attaquant.
+
+## Alternatives écartées
+
+**Le statu quo : le simulateur emprunte le token d'un device existant.** C'est ce que décrivait
+[SIMULATOR.md](../SIMULATOR.md). Écarté parce qu'il rend l'observation destructrice — regarder ce qu'affiche une
+dalle l'éteint — et parce qu'il laisse `isSimulator` mentir. Il fait en outre de la page de debug l'endroit où
+l'on saisit le credential d'un device de production.
+
+**Supprimer le drapeau.** L'autre façon cohérente de lever la contradiction : un device est un device, et rien
+ne le qualifie. Écarté parce qu'on perd ce qui a de la valeur dans la distinction. Une dalle éteinte et un onglet
+fermé produisent exactement le même `offline` : sans la nature du device, la supervision ne peut pas dire ce
+qu'elle est en train de montrer, et le simulateur ne peut pas présélectionner les devices qui le concernent.
+
+**Conserver `isSimulator`, en le rendant structurant.** C'est le changement minimal, et il suffirait. Écarté
+surtout pour le nom : `isSimulator` se lit comme un drapeau d'affichage, il a été traité comme tel, et c'est
+précisément ainsi que la contradiction est née. Un booléen ferme par ailleurs l'ensemble définitivement, alors
+qu'un troisième client — une capture, un enregistreur — est concevable. L'énumération est une réserve à bas coût,
+pas un plan : deux valeurs existent aujourd'hui, et rien de plus n'est prévu.
+
+**Un simulateur hors registre, sans device ni token.** Une page qui recevrait les frames par le plan de contrôle
+ou depuis Adonis. Écarté : ce serait une prévisualisation, elle n'exercerait plus le protocole device, et il
+faudrait un second chemin d'émission dans le renderer. C'est exactement ce que
+[SIMULATOR.md](../SIMULATOR.md) refuse d'être.
+
+## Conséquences
+
+- **L'observation sans perturbation devient le chemin normal, et gagne au change.** Un device simulateur portant
+  la même scène qu'une dalle tombe dans le **même groupe de rendu** ([ADR-0017](0017-rendu-mutualise.md)) : le
+  renderer calcule une seule frame pour les deux. À géométrie et `maxFps` identiques, le simulateur reçoit donc
+  les mêmes frames que la dalle — au `sequence` près, qui appartient à chaque connexion, et à l'arbitrage
+  `FULL`/`DELTA` près, qui dépend de l'historique de chaque connexion.
+- **Ce qu'on perd** : on ne voit plus les octets exacts que reçoit *une* dalle donnée sur *sa* socket. Un défaut
+  propre à cette connexion reste donc invisible au simulateur. La reproduction ci-dessus rejoue le contenu, pas
+  la connexion.
+- **La règle « une seule connexion active par device » ne change pas**, mais son illustration change : simulateur
+  et matériel ne se disputent plus un device. Elle reste observable — deux onglets sur le même device simulateur
+  — et reste nécessaire pour sa raison propre, la socket restée ouverte après une coupure WiFi
+  ([ADR-0011](0011-auth-premier-message.md)).
+- Le dashboard doit pouvoir créer un device simulateur sans matériel en face : même formulaire, même appairage,
+  même token ([ADR-0012](0012-format-des-tokens.md)).
+- Les devices issus de la migration depuis `matrices` sont tous `hardware`.

--- a/docs/adr/0021-credential-du-simulateur-par-rotation.md
+++ b/docs/adr/0021-credential-du-simulateur-par-rotation.md
@@ -1,0 +1,78 @@
+# ADR-0021 — Le simulateur obtient son credential par rotation à l'ouverture
+
+**Statut** : Accepté — 2026-08-31
+
+## Contexte
+
+[SIMULATOR.md](../SIMULATOR.md) attendait de l'utilisateur qu'il choisisse un device **et saisisse son token**.
+Or [ADR-0012](0012-format-des-tokens.md) veut qu'un token soit affiché une seule fois, à l'appairage, et que
+seule son empreinte soit conservée. Le dashboard ne peut donc pas le redonner : il ne l'a plus.
+
+L'attendu revenait ainsi à demander à l'utilisateur d'avoir archivé à la main le credential d'une page de debug
+qu'il ouvre depuis une session déjà authentifiée. En pratique il ne l'a pas, et il recrée un device à chaque
+fois.
+
+[ADR-0020](0020-simulateur-device-declare.md) rend le problème net : un device simulateur n'existe que pour être
+ouvert depuis le dashboard. Un credential qu'on ne peut pas récupérer n'a alors aucun porteur.
+
+## Décision
+
+**Le dashboard fait tourner le credential du device simulateur au moment où l'utilisateur ouvre le simulateur**,
+et remet le secret frais à la page.
+
+```http
+POST /api/v1/devices/:id/credential      → { "token": "mxd_71ce04ba82df_4d2f…" }
+```
+
+- La rotation vaut pour **tout** device : c'est la réponse à une fuite, que
+  [ADR-0012](0012-format-des-tokens.md) nommait déjà sans qu'aucune route ne l'offre. Elle n'est **automatique
+  et sans confirmation que pour `kind = simulator`**, parce que personne d'autre ne détient ce credential. Sur un
+  device `hardware`, la même rotation est une action explicite et avertie : la dalle s'éteint jusqu'à
+  reprovisionnement.
+- **La règle « affiché une seule fois » n'est pas assouplie.** Chaque token reste montré une fois, à sa
+  création. On ne relit pas un secret, on en crée un.
+- Le secret vit **en mémoire dans la page**, jamais en `localStorage` : un nouveau est à un clic, le persister
+  n'apporte rien qu'une exposition.
+- Un événement de plan de contrôle, `device.credential_rotated`, porte le nouveau couple préfixe/empreinte au
+  renderer, qui remplace son entrée de cache et **ferme la connexion en cours** avec `ERROR 0x09` — le token
+  qu'elle avait présenté n'est plus valide. Aucun nouveau code d'erreur.
+- **Ordre imposé** : Adonis émet l'événement avant de rendre le secret à la page.
+- **Adonis refuse la rotation si le renderer est hors ligne.** Le secret frais ne pourrait pas l'atteindre, et
+  l'ancien serait détruit pour rien. Un renderer auto-hébergé qui a perdu son canal continue de servir ses
+  dalles ([ADR-0008](0008-renderer-autonome.md)) mais ne peut plus apprendre une empreinte. Le refus nomme sa
+  cause ; `renderers.status` pouvant être en retard, c'est une politesse, pas une garantie.
+- **Fenêtre de course.** Si le simulateur se présente avant que le renderer n'ait appliqué l'événement, il reçoit
+  `ERROR 0x04`. Le simulateur réessaie alors un nombre borné de fois, et **lui seul, et seulement dans les
+  secondes qui suivent une rotation qu'il a lui-même demandée** : le refus y est transitoire par construction.
+  Ailleurs, rejouer un credential refusé reste exactement ce qu'on ne veut pas.
+
+## Alternatives écartées
+
+**Stocker le token des devices simulateurs en clair pour pouvoir le redonner.** La solution évidente, et celle
+qui vide [ADR-0012](0012-format-des-tokens.md) de son contenu : sa valeur tient à ce qu'aucun secret ne soit
+relisible. Une exception « seulement pour les simulateurs » est une exception qui se propage, et la V1 stockait
+déjà les tokens en clair — c'est le défaut qu'on vient de corriger.
+
+**Un credential de session court, à côté du token permanent.** Le renderer connaîtrait deux empreintes par
+device, avec une expiration à gérer, soit un second mécanisme de bail à côté de
+[ADR-0015](0015-bail-de-session-device.md). Écarté parce que la rotation obtient le même résultat sans notion
+nouvelle : un device simulateur n'a aucun credential à préserver, donc rien ne justifie d'en maintenir deux.
+
+**La saisie manuelle, c'est-à-dire le statu quo.** Écartée faute d'objet : il n'y a rien à saisir.
+
+**Une voie de frames authentifiée par la session utilisateur, sans token de device.** Ce serait un second chemin
+d'entrée dans le renderer, et le simulateur cesserait d'exercer le protocole device — donc de vérifier quoi que
+ce soit ([ADR-0020](0020-simulateur-device-declare.md)).
+
+## Conséquences
+
+- [ADR-0012](0012-format-des-tokens.md) gagne l'endpoint qui lui manquait : « une rotation reste la seule
+  réponse à une fuite » n'était réalisable nulle part.
+- **Ouvrir le simulateur invalide l'onglet précédent.** C'est cohérent avec une seule connexion active par
+  device, mais la cause est différente : ici l'ancienne connexion tombe parce que son token est mort, pas parce
+  qu'une nouvelle l'a remplacée.
+- **Le `token_prefix` d'un device simulateur change à chaque ouverture.** Il ne peut donc pas servir à suivre ce
+  device dans les journaux : un préfixe identifie un credential, l'`id` identifie un device.
+- **Piste non tranchée** : Adonis n'a aujourd'hui aucun accusé de réception du renderer, ce qui laisse la
+  fenêtre de course ouverte et traitée par un réessai. L'enveloppe porte déjà un `id` « pour corrélation », donc
+  la porte est ouverte. À reprendre si le réessai se révèle insuffisant en pratique.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,3 +35,6 @@ rouvre en refaisant toute l'analyse.
 | [0014](0014-sources-de-donnees-cote-adonis.md) | Les sources de données appartiennent à Adonis | Proposé |
 | [0015](0015-bail-de-session-device.md) | Bail de session device, borné par l'absence de contact | Accepté |
 | [0016](0016-transports-declares-par-le-renderer.md) | Le renderer déclare ses transports | Accepté |
+| [0017](0017-rendu-mutualise.md) | Rendu mutualisé par groupe de devices équivalents | Accepté |
+| [0018](0018-geometrie-native-de-la-scene.md) | La scène porte sa géométrie native, agrandissement entier | Accepté |
+| [0019](0019-cadence-portee-par-la-scene.md) | La cadence appartient à la scène, le device en pose le plafond | Accepté |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@ rouvre en refaisant toute l'analyse.
 | [0017](0017-rendu-mutualise.md) | Rendu mutualisé par groupe de devices équivalents | Accepté |
 | [0018](0018-geometrie-native-de-la-scene.md) | La scène porte sa géométrie native, agrandissement entier | Accepté |
 | [0019](0019-cadence-portee-par-la-scene.md) | La cadence appartient à la scène, le device en pose le plafond | Accepté |
+| [0020](0020-simulateur-device-declare.md) | Le simulateur est un device déclaré, pas un device emprunté | Accepté |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,6 @@ rouvre en refaisant toute l'analyse.
 | [0011](0011-auth-premier-message.md) | Authentification device par premier message binaire | Accepté |
 | [0012](0012-format-des-tokens.md) | Token à préfixe public et secret haché | Accepté |
 | [0013](0013-provisionnement-du-renderer-plateforme.md) | Credential du renderer plateforme provisionné par l'environnement | Accepté |
+| [0014](0014-sources-de-donnees-cote-adonis.md) | Les sources de données appartiennent à Adonis | Proposé |
+| [0015](0015-bail-de-session-device.md) | Bail de session device, borné par l'absence de contact | Accepté |
+| [0016](0016-transports-declares-par-le-renderer.md) | Le renderer déclare ses transports | Accepté |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@ rouvre en refaisant toute l'analyse.
 | [0018](0018-geometrie-native-de-la-scene.md) | La scène porte sa géométrie native, agrandissement entier | Accepté |
 | [0019](0019-cadence-portee-par-la-scene.md) | La cadence appartient à la scène, le device en pose le plafond | Accepté |
 | [0020](0020-simulateur-device-declare.md) | Le simulateur est un device déclaré, pas un device emprunté | Accepté |
+| [0021](0021-credential-du-simulateur-par-rotation.md) | Le simulateur obtient son credential par rotation à l'ouverture | Accepté |


### PR DESCRIPTION
> **Draft.** The read-through of `docs/` is complete — every ADR and every document — and the corrections it
> produced are here. Kept as a draft until the review of this pull request itself.

A pass over `docs/`, driven by re-reading the specs in order. Eight new decision records, five amended, and the
documents that contradicted them brought back in line.

## New decisions

**ADR-0014 — Les sources de données appartiennent à Adonis** (`Proposé`)
All displayed values come from Adonis through one mechanism, with no exception for the clock: a source has a
name, a value and a validity, a scene binds to named sources, and the renderer is a pure function of
`(scene, values)`. Values freeze between pushes — the renderer extrapolates nothing.

Left as `Proposé` on purpose: the status existed in `adr/README.md` but had never been used, and nothing else in
the docs conforms to it yet. The header states what has to be settled before it can be accepted.

**ADR-0015 — Bail de session device, borné par l'absence de contact** (`Accepté`)
Fixes a real defect. `PROTOCOL-CONTROL.md` said cache expiry "refuses new connections but does not cut
established ones" — and since the renderer → device link is permanent, a connected device never
re-authenticates, so expiry never applied to a lit panel. The mechanism meant to bound the exposure window was
inert against the only population that mattered.

The trigger becomes the *absence* of contact rather than the receipt of a revocation, which is the only thing
that can act while the channel is down. `devices.offlineGrace`, 7 days by default, `null` for unlimited.

**ADR-0016 — Le renderer déclare ses transports** (`Accepté`)
`renderer_url` was specified as `wss://` with no account of how a NATed renderer on a LAN address obtains a
certificate. A self-signed one that nobody pins is encryption without authentication. The renderer now declares
`endpoints` — `wss://`, `ws://`, or both — the bootstrap hands the list over as-is, and the client picks. The
firmware prefers `wss://`; the simulator keeps only what the browser allows from the origin serving the page.

**ADR-0017 — Rendu mutualisé par groupe** (`Accepté`)
The model already binds N devices to one scene, but nothing said what the renderer does with that, and
`sync.full` copied the full scene config into every device entry — allowing two divergent copies of one scene at
one version, and presenting as N independent contents what has to be computed once. The control plane is
normalised (a top-level `scenes` section, devices carrying only a `scene_id`) and the renderer computes one
frame per group. Sharing stops at the pixel buffer: header, sequence, previous frame (hence DELTA), backpressure
and connection all stay per device.

**ADR-0018 — La scène porte sa géométrie native** (`Accepté`)
`scenes.config` carried no geometry, so a 64×32 scene could be assigned to a 32×32 panel, and a scene had no
stable meaning — a glyph at (10, 4) landed somewhere different on each panel. A scene now declares
`width`/`height` and can only be assigned to a device whose geometry is an **integer multiple, same factor on
both axes**. On an LED panel ×k is pixel replication, not resampling: exact, no blur. Downscale, per-axis
factors and non-integer factors are refused at write time.

**ADR-0019 — La cadence appartient à la scène** (`Accepté`)
`devices.targetFps` conflated two questions: what the content needs (a clock does not need 30 FPS — a scene
property, known to its author) and what the link sustains (a crowded WiFi — a device property, known to its
owner). The cadence moves to `scenes.targetFps`; the device keeps an optional emission cap, `maxFps`, `null` by
default. A capped device receives one frame out of `n = ⌈targetFps / maxFps⌉` — integer, so 30 capped at 20
emits at an even 15 rather than a stuttering 20.

**ADR-0020 — Le simulateur est un device déclaré, pas un device emprunté** (`Accepté`)
Two documents described two models. `DATA-MODEL.md` carried an `isSimulator` flag described as telling
simulators apart "in the interface" — a label; `SIMULATOR.md` had the simulator connect with **any** device's
token, hardware included, and turned that into intended behaviour: "opening the simulator on a lit device cuts
the panel". So the flag described nothing anything kept true, and observing a panel meant typing a production
token into a debug page and blanking the panel while looking at it.

A device now declares its nature: `devices.kind` is `hardware` or `simulator`, set at creation and immutable,
and the simulator only offers `kind = simulator` devices. It is a registry rule, not an authentication boundary
— nothing in `DEVICE_HELLO` distinguishes a browser from firmware, and both tokens belong to the same user, so
`kind` never travels on the control plane and the renderer stays unaware of it, as `SIMULATOR.md` requires.

Watching a panel becomes: give a simulator device the same scene. ADR-0017 then puts both in the same render
group, so the renderer computes one frame for the two and — at equal geometry and `maxFps` — the simulator
receives what the panel receives, modulo `sequence` and the FULL/DELTA arbitration, which are per connection.
What is lost is recorded: this mirrors the content, not the panel's own socket.

**ADR-0021 — Le simulateur obtient son credential par rotation à l'ouverture** (`Accepté`)
`SIMULATOR.md` expected the user to *type in* the device token. A token is shown once and only its hash is kept
(ADR-0012), so the dashboard cannot hand it back: the expectation amounted to asking the user to have archived
by hand the credential of a debug page they open from an already authenticated session.

The dashboard now **rotates** the simulator device's credential when the simulator is opened and passes the
fresh secret to the page — `POST /api/v1/devices/:id/credential`. The once-only rule is not relaxed: a secret is
never re-read, a new one is created. Rotation is available for any device — it is the answer to a leak that
ADR-0012 named without any route offering it — but automatic and unconfirmed only for `kind = simulator`, since
nobody else holds that credential; on hardware it blanks the panel until reprovisioning.

A new control-plane event, `device.credential_rotated`, carries the new prefix/hash and makes the renderer close
the current connection with the existing `ERROR 0x09`. Adonis emits it **before** returning the secret, and
refuses to rotate while the renderer is offline — a secret it cannot learn would only destroy the previous one.
The remaining race is handled by a bounded retry, allowed **only** in the seconds following a rotation the
client itself requested; the control plane has no acknowledgement today, which is recorded as untreated.

Together, 0017–0019 reduce the group key to `scene_id` + `version`: **one scene, one render loop**, and no
device setting can move a device between groups — brightness, geometry and cap all apply after the computation.

## Amended

- **ADR-0001** — 30 FPS becomes a setting instead of a protocol constant (1–60, default 30). The protocol
  already carried it in `CONFIG` and `sync.full`; only the ADR treated it as fixed. ADR-0019 later moves where
  the setting lives.
- **ADR-0002** — the reason for choosing Go was buried in a subordinate clause of the rejected alternative. The
  rationale now sits in the decision, with an order of magnitude derived from the `PERFORMANCE.md` budgets:
  13 ms of CPU per frame per device, 390 ms/s at 30 FPS, so one core saturates at two or three devices. Also
  states plainly that no comparative benchmark was ever run, and that its "per device" figure is the **worst
  case** — N devices on N distinct scenes — since ADR-0017.
- **ADR-0004 / ARCHITECTURE** — "le chemin 30 FPS" named a constant that no longer exists; now "le chemin de
  rendu".
- **ADR-0006** — `Scene` is "a content", now "a content written for a given geometry", with why that does not
  re-couple it to a panel.
- **ADR-0008** — "dernier état connu" says nothing about displayed values; that question is ADR-0014's. It also
  asserted that the renderer needs persistent storage without saying why: an in-memory cache survives an outage
  perfectly well as long as the process lives, and it is the **restart** that forces persistence. A renderer
  restarting while the platform is unreachable comes back knowing no hash, refuses every device and blanks
  exactly the panels this ADR promises to keep lit. Writing that surfaced a defect: the **last successful
  control contact timestamp** has to be persisted too, otherwise restarting resets the lease clock and ADR-0015's
  bound is bypassable by relaunching the process. Added to the conformance list in `SELF-HOSTING.md`, where an
  implementer reads it.

## Device protocol cleanup

Nothing implements this protocol yet, so the codes are still free to move — they freeze at the first firmware
release.

**Message types renumbered into session order** — `DEVICE_HELLO` 0x01, `CONFIG` 0x02, `FULL_FRAME` 0x03,
`DELTA_FRAME` 0x04, `STATUS_UPDATE` 0x05 (unchanged), `ERROR` 0x06 — and the detailed sections reordered to
match. The old 0x06–0x07 hole was a fossil of removed messages, and a hole in a code table reads as a deliberate
reservation. `0x00` is now reserved in both tables: a null byte is what you read from an uninitialised buffer, so
it is the one value whose invalidity separates a bug from a message. The two namespaces are also called out
explicitly, since they visually overlap — the 0x06 of the message table is `ERROR`, the 0x06 of the error table
is "unsupported protocol version".

**Duplicate error code fixed.** The table carried two `0x09`: "expired lease", added with ADR-0015, and "unknown
or revoked device", which predated it and is referenced by the revocation path in `PROTOCOL-CONTROL.md`. The
lease moves to `0x0A`, and the sentence that could not be written before — "0x0A is neither 0x04 nor 0x09" — now
is.

**`session_id` removed from `CONFIG`.** It appeared in the spec rewrite and never got a contract: no message
echoed it, no rule read it, and it was the only occurrence of the word in the whole corpus. Four bytes out of
fourteen. `CONFIG` is now 10 bytes. Same standard the document already applies to metrics: an invented field is
worse than a missing one.

**`sequence` specified.** It was used — `last_applied_sequence` echoes it and the end-to-end latency measurement
derives from it — but its rules were nowhere, and ADR-0017 had just made the main one ambiguous. It belongs to a
device connection (not the scene or the group), resets to 0 on every connect, wraps modulo 2³², and the device
only echoes it: no gap detection, no retransmission.

**`brightness` removed from the `FULL_FRAME` header.** Two writers for one value forced a precedence rule, and
with it a defect: a frame computed before a brightness change would overwrite the fresh setting on arrival.
`CONFIG` is the only carrier now. The header drops to 9 bytes, so a 64×32 full frame is 6153 bytes and the
FULL/DELTA tipping point becomes `(3P + 2) / 5` — recomputed across `PERFORMANCE.md`, `README.md` and ADR-0003.
Displayed throughputs are unchanged: the missing byte disappears in the rounding.

## Device geometry rule dropped

`DATA-MODEL.md` required device `width` and `height` to be "multiples de la géométrie d'une dalle". No field
carried a panel geometry, so the rule was never checkable — and the constraint that actually matters is a
different one, already specified: a device only accepts a scene whose geometry divides its own by the same
integer factor on both axes (ADR-0018). `width` and `height` are now simply strictly positive, under the
65536-pixel cap. #17 records the resolution; `chainLength` stays wiring information for the firmware and
describes nothing about the image.

## Documentation index

`README.md` claimed "the 11 architecture decisions" — there are 21. The count is gone rather than corrected: it
rots at every ADR, and `adr/README.md` already lists them. The cadence line still said "per device", which
ADR-0019 made false. "What is still open" listed two subjects; it now separates the two deliberately-empty
extension points from the five genuinely undecided threads, each with its entry point — a reader could only find
those by reading all 21 files. Added a header warning that the specs describe the target and the code implements
part of it, which `CLAUDE.md` says to me but nothing said to a human reader of `docs/`.

## Brought back in line

`DATA-MODEL.md` gained `brightness` and `offlineGrace` on `Device` — the first was already being sent in
`sync.full` and `CONFIG` while existing in no table — plus `width`, `height` and `targetFps` on `Scene`, and the
assignment rule between the two. `Renderer.endpoint` became `endpoints`. `PERFORMANCE.md` states which cadence
its per-frame budget is valid at, since the cadence is no longer fixed. `SELF-HOSTING.md` promised a renderer
would *never* blank a panel during an outage, which ADR-0015 makes false; it now says "never from an outage
alone". The simulator is recorded as a page of the Nuxt dashboard, which made "Nuxt never talks to a renderer"
false in the responsibilities table — the simulator now has its own row.

## Issues

- Opened #54 — `Renderer.endpoint` → `endpoints`, a follow-up to #16, which has already shipped and merged.
- #17 and #18 rewritten: geometry and cadence move to `scenes`, the device keeps `maxFps`, and the scene/device
  compatibility rule becomes an acceptance criterion.
- #17 and #48 updated for `kind`: the field replaces `isSimulator` in the model, and the simulator selects
  among simulator devices instead of borrowing a hardware identity.
- Opened #57 — detecting a device flapping between two clients, listed in epic #8. The `ERROR 0x08` eviction
  loop makes `device.status` beat, which is a free token-theft signal ADR-0015 recorded and nothing used.
  Detection stays in Adonis; the answer it points at is rotation (#56).
- Opened #56 — credential rotation, listed in epic #7. #48 gains the open-the-simulator flow: no token typed
  in, and a retry bounded to the window right after its own rotation.
- #34 rewritten: its deliverable said "per-device loop", the opposite of ADR-0017.
- #32 had an acceptance criterion stating the opposite of ADR-0015.
- #39 and #40 rewritten: their deliverables quoted the old message codes and the old header size.
- #25, #27, #31, #33, #35, #42, #44, #48 updated for the endpoint list, the renumbered codes, `ERROR 0x0A`, the
  normalised sync payloads, the per-device `sequence` and the DELTA baseline on a capped device.

## Not addressed

- Nothing specifies what a renderer does when a device reports a measured `fps` far below its effective cadence.
  ADR-0019 records why the obvious answer — an automatic cap derived from the measurement — is a trap.
- The `k×k` expansion is done by the renderer, so a 128×64 device on a 64×32 scene receives four times more bytes
  than information. Moving it into the firmware would divide that by k² on the most constrained link in the
  system. Recorded in ADR-0018 as untreated, to reopen once the firmware exists.
- The control plane has no acknowledgement, so Adonis cannot know a rotation reached the renderer before it
  hands out the secret. Recorded in ADR-0021; the envelope already carries an `id` "for correlation".

