### PR TITLE
Epic #7: the Scene entity

### DIFF
--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -102,7 +102,7 @@ Un contenu à afficher.
 | `width` / `height` | integer | Géométrie native, celle pour laquelle la scène est écrite ([ADR-0018](adr/0018-geometrie-native-de-la-scene.md)) |
 | `targetFps` | integer | Cadence à laquelle la scène est évaluée, 1 à 60. Défaut 30 ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) |
 | `config` | jsonb | Configuration versionnée et validée |
-| `version` | integer | Incrémenté à chaque modification, sert au diff du plan de contrôle |
+| `version` | integer | Incrémenté à chaque modification affectant le rendu (`width`, `height`, `targetFps`, `config` — pas `name`), sert au diff du plan de contrôle |
 | `createdAt` / `updatedAt` | timestamptz | |
 
 **Règles**

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -102,7 +102,7 @@ Un contenu à afficher.
 | `width` / `height` | integer | Géométrie native, celle pour laquelle la scène est écrite ([ADR-0018](adr/0018-geometrie-native-de-la-scene.md)) |
 | `targetFps` | integer | Cadence à laquelle la scène est évaluée, 1 à 60. Défaut 30 ([ADR-0019](adr/0019-cadence-portee-par-la-scene.md)) |
 | `config` | jsonb | Configuration versionnée et validée |
-| `version` | integer | Incrémenté à chaque modification affectant le rendu (`width`, `height`, `targetFps`, `config` — pas `name`), sert au diff du plan de contrôle |
+| `version` | integer | Incrémenté à chaque modification, sert au diff du plan de contrôle |
 | `createdAt` / `updatedAt` | timestamptz | |
 
 **Règles**

--- a/webapp/apps/backend/.adonisjs/client/data.d.ts
+++ b/webapp/apps/backend/.adonisjs/client/data.d.ts
@@ -8,6 +8,7 @@ import type { InferData, InferVariants } from '@adonisjs/core/types/transformers
 import type MatrixTransformer from '#transformers/matrix_transformer'
 import type RendererTransformer from '#transformers/renderer_transformer'
 import type RendererWithTokenTransformer from '#transformers/renderer_with_token_transformer'
+import type SceneTransformer from '#transformers/scene_transformer'
 import type UserTransformer from '#transformers/user_transformer'
 
 export namespace Data {
@@ -22,6 +23,10 @@ export namespace Data {
   export type RendererWithToken = InferData<RendererWithTokenTransformer>
   export namespace RendererWithToken {
     export type Variants = InferVariants<RendererWithTokenTransformer>
+  }
+  export type Scene = InferData<SceneTransformer>
+  export namespace Scene {
+    export type Variants = InferVariants<SceneTransformer>
   }
   export type User = InferData<UserTransformer>
   export namespace User {

--- a/webapp/apps/backend/.adonisjs/client/registry/index.ts
+++ b/webapp/apps/backend/.adonisjs/client/registry/index.ts
@@ -96,6 +96,36 @@ const routes = {
     tokens: [{"old":"/api/v1/renderers/:id/token","type":0,"val":"api","end":""},{"old":"/api/v1/renderers/:id/token","type":0,"val":"v1","end":""},{"old":"/api/v1/renderers/:id/token","type":0,"val":"renderers","end":""},{"old":"/api/v1/renderers/:id/token","type":1,"val":"id","end":""},{"old":"/api/v1/renderers/:id/token","type":0,"val":"token","end":""}],
     types: placeholder as Registry['renderers.token']['types'],
   },
+  'scenes.index': {
+    methods: ["GET","HEAD"],
+    pattern: '/api/v1/scenes',
+    tokens: [{"old":"/api/v1/scenes","type":0,"val":"api","end":""},{"old":"/api/v1/scenes","type":0,"val":"v1","end":""},{"old":"/api/v1/scenes","type":0,"val":"scenes","end":""}],
+    types: placeholder as Registry['scenes.index']['types'],
+  },
+  'scenes.show': {
+    methods: ["GET","HEAD"],
+    pattern: '/api/v1/scenes/:id',
+    tokens: [{"old":"/api/v1/scenes/:id","type":0,"val":"api","end":""},{"old":"/api/v1/scenes/:id","type":0,"val":"v1","end":""},{"old":"/api/v1/scenes/:id","type":0,"val":"scenes","end":""},{"old":"/api/v1/scenes/:id","type":1,"val":"id","end":""}],
+    types: placeholder as Registry['scenes.show']['types'],
+  },
+  'scenes.store': {
+    methods: ["POST"],
+    pattern: '/api/v1/scenes',
+    tokens: [{"old":"/api/v1/scenes","type":0,"val":"api","end":""},{"old":"/api/v1/scenes","type":0,"val":"v1","end":""},{"old":"/api/v1/scenes","type":0,"val":"scenes","end":""}],
+    types: placeholder as Registry['scenes.store']['types'],
+  },
+  'scenes.patch': {
+    methods: ["PATCH"],
+    pattern: '/api/v1/scenes/:id',
+    tokens: [{"old":"/api/v1/scenes/:id","type":0,"val":"api","end":""},{"old":"/api/v1/scenes/:id","type":0,"val":"v1","end":""},{"old":"/api/v1/scenes/:id","type":0,"val":"scenes","end":""},{"old":"/api/v1/scenes/:id","type":1,"val":"id","end":""}],
+    types: placeholder as Registry['scenes.patch']['types'],
+  },
+  'scenes.delete': {
+    methods: ["DELETE"],
+    pattern: '/api/v1/scenes/:id',
+    tokens: [{"old":"/api/v1/scenes/:id","type":0,"val":"api","end":""},{"old":"/api/v1/scenes/:id","type":0,"val":"v1","end":""},{"old":"/api/v1/scenes/:id","type":0,"val":"scenes","end":""},{"old":"/api/v1/scenes/:id","type":1,"val":"id","end":""}],
+    types: placeholder as Registry['scenes.delete']['types'],
+  },
 } as const satisfies Record<string, AdonisEndpoint>
 
 export { routes }

--- a/webapp/apps/backend/.adonisjs/client/registry/schema.d.ts
+++ b/webapp/apps/backend/.adonisjs/client/registry/schema.d.ts
@@ -187,4 +187,64 @@ export interface Registry {
       errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/renderers_controller').default['rotateToken']>>> | { status: 422; response: { errors: SimpleError[] } }
     }
   }
+  'scenes.index': {
+    methods: ["GET","HEAD"]
+    pattern: '/api/v1/scenes'
+    types: {
+      body: {}
+      paramsTuple: []
+      params: {}
+      query: {}
+      response: ExtractResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['index']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['index']>>>
+    }
+  }
+  'scenes.show': {
+    methods: ["GET","HEAD"]
+    pattern: '/api/v1/scenes/:id'
+    types: {
+      body: {}
+      paramsTuple: [ParamValue]
+      params: { id: ParamValue }
+      query: ExtractQueryForGet<InferInput<(typeof import('#validators/scene').showSceneValidator)>>
+      response: ExtractResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['show']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['show']>>> | { status: 422; response: { errors: SimpleError[] } }
+    }
+  }
+  'scenes.store': {
+    methods: ["POST"]
+    pattern: '/api/v1/scenes'
+    types: {
+      body: ExtractBody<InferInput<(typeof import('#validators/scene').createSceneValidator)>>
+      paramsTuple: []
+      params: {}
+      query: ExtractQuery<InferInput<(typeof import('#validators/scene').createSceneValidator)>>
+      response: ExtractResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['store']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['store']>>> | { status: 422; response: { errors: SimpleError[] } }
+    }
+  }
+  'scenes.patch': {
+    methods: ["PATCH"]
+    pattern: '/api/v1/scenes/:id'
+    types: {
+      body: ExtractBody<InferInput<(typeof import('#validators/scene').patchSceneValidator)>>
+      paramsTuple: [ParamValue]
+      params: { id: ParamValue }
+      query: ExtractQuery<InferInput<(typeof import('#validators/scene').patchSceneValidator)>>
+      response: ExtractResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['patch']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['patch']>>> | { status: 422; response: { errors: SimpleError[] } }
+    }
+  }
+  'scenes.delete': {
+    methods: ["DELETE"]
+    pattern: '/api/v1/scenes/:id'
+    types: {
+      body: ExtractBody<InferInput<(typeof import('#validators/scene').deleteSceneValidator)>>
+      paramsTuple: [ParamValue]
+      params: { id: ParamValue }
+      query: ExtractQuery<InferInput<(typeof import('#validators/scene').deleteSceneValidator)>>
+      response: ExtractResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['delete']>>>
+      errorResponse: ExtractErrorResponse<Awaited<ReturnType<import('#controllers/scenes_controller').default['delete']>>> | { status: 422; response: { errors: SimpleError[] } }
+    }
+  }
 }

--- a/webapp/apps/backend/.adonisjs/client/registry/tree.d.ts
+++ b/webapp/apps/backend/.adonisjs/client/registry/tree.d.ts
@@ -33,4 +33,11 @@ export interface ApiDefinition {
     delete: typeof routes['renderers.delete']
     token: typeof routes['renderers.token']
   }
+  scenes: {
+    index: typeof routes['scenes.index']
+    show: typeof routes['scenes.show']
+    store: typeof routes['scenes.store']
+    patch: typeof routes['scenes.patch']
+    delete: typeof routes['scenes.delete']
+  }
 }

--- a/webapp/apps/backend/.adonisjs/server/controllers.ts
+++ b/webapp/apps/backend/.adonisjs/server/controllers.ts
@@ -8,5 +8,6 @@ export const controllers = {
   NewAccount: () => import('#controllers/new_account_controller'),
   Profile: () => import('#controllers/profile_controller'),
   Renderers: () => import('#controllers/renderers_controller'),
+  Scenes: () => import('#controllers/scenes_controller'),
   Session: () => import('#controllers/session_controller'),
 }

--- a/webapp/apps/backend/.adonisjs/server/policies.ts
+++ b/webapp/apps/backend/.adonisjs/server/policies.ts
@@ -1,5 +1,6 @@
 export const policies = {
   MatrixPolicy: () => import('#policies/matrix_policy'),
   RendererPolicy: () => import('#policies/renderer_policy'),
+  ScenePolicy: () => import('#policies/scene_policy'),
 }
 

--- a/webapp/apps/backend/.adonisjs/server/routes.d.ts
+++ b/webapp/apps/backend/.adonisjs/server/routes.d.ts
@@ -19,6 +19,11 @@ export type ScannedRoutes = {
     'renderers.patch': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'renderers.delete': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'renderers.token': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'scenes.index': { paramsTuple?: []; params?: {} }
+    'scenes.show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'scenes.store': { paramsTuple?: []; params?: {} }
+    'scenes.patch': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'scenes.delete': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
   }
   GET: {
     'profile.profile.show': { paramsTuple?: []; params?: {} }
@@ -26,6 +31,8 @@ export type ScannedRoutes = {
     'matrices.show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'renderers.index': { paramsTuple?: []; params?: {} }
     'renderers.show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'scenes.index': { paramsTuple?: []; params?: {} }
+    'scenes.show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
   }
   HEAD: {
     'profile.profile.show': { paramsTuple?: []; params?: {} }
@@ -33,6 +40,8 @@ export type ScannedRoutes = {
     'matrices.show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'renderers.index': { paramsTuple?: []; params?: {} }
     'renderers.show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'scenes.index': { paramsTuple?: []; params?: {} }
+    'scenes.show': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
   }
   POST: {
     'auth.new_account.store': { paramsTuple?: []; params?: {} }
@@ -41,14 +50,17 @@ export type ScannedRoutes = {
     'matrices.store': { paramsTuple?: []; params?: {} }
     'renderers.store': { paramsTuple?: []; params?: {} }
     'renderers.token': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'scenes.store': { paramsTuple?: []; params?: {} }
   }
   PATCH: {
     'matrices.patch': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'renderers.patch': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'scenes.patch': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
   }
   DELETE: {
     'matrices.delete': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
     'renderers.delete': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
+    'scenes.delete': { paramsTuple: [ParamValue]; params: {'id': ParamValue} }
   }
 }
 declare module '@adonisjs/core/types/http' {

--- a/webapp/apps/backend/app/constants/scene.ts
+++ b/webapp/apps/backend/app/constants/scene.ts
@@ -1,0 +1,12 @@
+/**
+ * A device addresses its pixels with a 16-bit index, which caps a panel at
+ * 65 536 pixels — 256×256 (docs/PROTOCOL-DEVICE.md). A scene authored above
+ * that could never be displayed, so the bound is enforced on the way in: by
+ * this constant in the validator and the service, and by a CHECK constraint
+ * in the `scenes` migration, which carries the literal because a migration
+ * must stay a frozen snapshot of the schema at its date.
+ *
+ * The frontend imports it too, through the package's `./constants/scene`
+ * export, so the client-side form and the API agree on one number.
+ */
+export const PROTOCOL_MAXIMUM_PIXELS = 65536

--- a/webapp/apps/backend/app/controllers/scenes_controller.ts
+++ b/webapp/apps/backend/app/controllers/scenes_controller.ts
@@ -1,0 +1,83 @@
+import ScenePolicy from '#policies/scene_policy'
+import { SceneService } from '#services/scene_service'
+import SceneTransformer from '#transformers/scene_transformer'
+import {
+  createSceneValidator,
+  deleteSceneValidator,
+  patchSceneValidator,
+  showSceneValidator,
+} from '#validators/scene'
+import { inject } from '@adonisjs/core'
+import { type HttpContext } from '@adonisjs/core/http'
+
+@inject()
+export default class ScenesController {
+  constructor(protected sceneService: SceneService) {}
+
+  async index({ auth, serialize }: HttpContext) {
+    const user = auth.getUserOrFail()
+
+    const scenes = await this.sceneService.getVisibleScenes(user.id)
+
+    return serialize(SceneTransformer.transform(scenes))
+  }
+
+  async show({ request, serialize, bouncer }: HttpContext) {
+    const {
+      params: { id: sceneId },
+    } = await request.validateUsing(showSceneValidator)
+
+    const scene = await this.sceneService.getSceneById(sceneId)
+
+    await bouncer.with(ScenePolicy).authorize('show', scene)
+
+    return serialize(SceneTransformer.transform(scene))
+  }
+
+  async store({ auth, request, serialize, response }: HttpContext) {
+    const { name, width, height, targetFps, config } =
+      await request.validateUsing(createSceneValidator)
+
+    const user = auth.getUserOrFail()
+
+    const scene = await this.sceneService.createScene({
+      name,
+      width,
+      height,
+      targetFps,
+      config,
+      userId: user.id,
+    })
+
+    return response.created(await serialize(SceneTransformer.transform(scene)))
+  }
+
+  async patch({ request, serialize, bouncer }: HttpContext) {
+    const {
+      params: { id: sceneId },
+      ...patch
+    } = await request.validateUsing(patchSceneValidator)
+
+    const scene = await this.sceneService.getSceneById(sceneId)
+
+    await bouncer.with(ScenePolicy).authorize('patch', scene)
+
+    const updatedScene = await this.sceneService.patchScene(scene, patch)
+
+    return serialize(SceneTransformer.transform(updatedScene))
+  }
+
+  async delete({ request, bouncer, response }: HttpContext) {
+    const {
+      params: { id: sceneId },
+    } = await request.validateUsing(deleteSceneValidator)
+
+    const scene = await this.sceneService.getSceneById(sceneId)
+
+    await bouncer.with(ScenePolicy).authorize('delete', scene)
+
+    await this.sceneService.deleteScene(scene)
+
+    return response.noContent()
+  }
+}

--- a/webapp/apps/backend/app/models/scene.ts
+++ b/webapp/apps/backend/app/models/scene.ts
@@ -1,0 +1,17 @@
+import { SceneSchema } from '#database/schema'
+import { beforeCreate, belongsTo } from '@adonisjs/lucid/orm'
+import User from './user.ts'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+
+export default class Scene extends SceneSchema {
+  static selfAssignPrimaryKey = true
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
+
+  @beforeCreate()
+  static assignUuid(scene: Scene) {
+    if (scene.id) return
+    scene.id = crypto.randomUUID()
+  }
+}

--- a/webapp/apps/backend/app/policies/scene_policy.ts
+++ b/webapp/apps/backend/app/policies/scene_policy.ts
@@ -1,0 +1,18 @@
+import type User from '#models/user'
+import type Scene from '#models/scene'
+import { BasePolicy } from '@adonisjs/bouncer'
+import type { AuthorizerResponse } from '@adonisjs/bouncer/types'
+
+export default class ScenePolicy extends BasePolicy {
+  show(user: User, scene: Scene): AuthorizerResponse {
+    return user.id === scene.userId
+  }
+
+  patch(user: User, scene: Scene): AuthorizerResponse {
+    return user.id === scene.userId
+  }
+
+  delete(user: User, scene: Scene): AuthorizerResponse {
+    return user.id === scene.userId
+  }
+}

--- a/webapp/apps/backend/app/services/scene_service.ts
+++ b/webapp/apps/backend/app/services/scene_service.ts
@@ -1,0 +1,103 @@
+import Scene from '#models/scene'
+import { sceneGeometrySchema, type SceneConfig } from '#validators/scene'
+import vine from '@vinejs/vine'
+
+const DEFAULT_SCENE_CONFIG: SceneConfig = { version: 1, nodes: [] }
+const DEFAULT_TARGET_FPS = 30
+
+export class SceneService {
+  async getVisibleScenes(userId: string) {
+    return Scene.query().where('user_id', userId).orderBy('created_at')
+  }
+
+  async getSceneById(sceneId: string) {
+    return Scene.findOrFail(sceneId)
+  }
+
+  async createScene({
+    name,
+    width,
+    height,
+    targetFps,
+    config,
+    userId,
+  }: {
+    name: string
+    width: number
+    height: number
+    targetFps?: number
+    config?: SceneConfig
+    userId: string
+  }) {
+    const scene = await Scene.create({
+      name,
+      width,
+      height,
+      userId,
+      targetFps: targetFps ?? DEFAULT_TARGET_FPS,
+      config: config ?? DEFAULT_SCENE_CONFIG,
+    })
+
+    /**
+     * `version` is a database default, so the fresh instance does not carry
+     * it. Reload so the response describes the stored row.
+     */
+    await scene.refresh()
+
+    return scene
+  }
+
+  async patchScene(
+    scene: Scene,
+    patch: Partial<{
+      name: string
+      width: number
+      height: number
+      targetFps: number
+      config: SceneConfig
+    }>
+  ) {
+    const mergedWidth = patch.width ?? scene.width
+    const mergedHeight = patch.height ?? scene.height
+
+    /**
+     * A patch touching only one of the two dimensions can't be checked by the
+     * request validator, which never sees the sibling value still in the row.
+     */
+    if (patch.width !== undefined || patch.height !== undefined) {
+      await vine.validate({
+        schema: sceneGeometrySchema,
+        data: { width: mergedWidth, height: mergedHeight },
+      })
+    }
+
+    /**
+     * Bumped when a render-relevant field is present in the patch, regardless
+     * of whether the new value differs from the stored one — an occasional
+     * spurious diff downstream is cheap, a missed one is a stale render.
+     * `name` alone never bumps it: the render group key is `scene_id` +
+     * `version` (docs/adr/0019-cadence-portee-par-la-scene.md), and a rename
+     * carries nothing a renderer needs to re-diff.
+     */
+    const rendersDifferently =
+      patch.width !== undefined ||
+      patch.height !== undefined ||
+      patch.targetFps !== undefined ||
+      patch.config !== undefined
+
+    scene.name = patch.name ?? scene.name
+    scene.width = mergedWidth
+    scene.height = mergedHeight
+    scene.targetFps = patch.targetFps ?? scene.targetFps
+    scene.config = patch.config ?? scene.config
+    if (rendersDifferently) scene.version += 1
+
+    await scene.save()
+
+    return scene
+  }
+
+  async deleteScene(scene: Scene) {
+    await scene.delete()
+  }
+}

--- a/webapp/apps/backend/app/services/scene_service.ts
+++ b/webapp/apps/backend/app/services/scene_service.ts
@@ -1,6 +1,5 @@
 import Scene from '#models/scene'
-import { sceneGeometrySchema, type SceneConfig } from '#validators/scene'
-import vine from '@vinejs/vine'
+import { sceneGeometryValidator, type SceneConfig } from '#validators/scene'
 
 const DEFAULT_SCENE_CONFIG: SceneConfig = { version: 1, nodes: [] }
 const DEFAULT_TARGET_FPS = 30
@@ -65,34 +64,41 @@ export class SceneService {
      * request validator, which never sees the sibling value still in the row.
      */
     if (patch.width !== undefined || patch.height !== undefined) {
-      await vine.validate({
-        schema: sceneGeometrySchema,
-        data: { width: mergedWidth, height: mergedHeight },
-      })
+      await sceneGeometryValidator.validate({ width: mergedWidth, height: mergedHeight })
     }
-
-    /**
-     * Bumped when a render-relevant field is present in the patch, regardless
-     * of whether the new value differs from the stored one — an occasional
-     * spurious diff downstream is cheap, a missed one is a stale render.
-     * `name` alone never bumps it: the render group key is `scene_id` +
-     * `version` (docs/adr/0019-cadence-portee-par-la-scene.md), and a rename
-     * carries nothing a renderer needs to re-diff.
-     */
-    const rendersDifferently =
-      patch.width !== undefined ||
-      patch.height !== undefined ||
-      patch.targetFps !== undefined ||
-      patch.config !== undefined
 
     scene.name = patch.name ?? scene.name
     scene.width = mergedWidth
     scene.height = mergedHeight
     scene.targetFps = patch.targetFps ?? scene.targetFps
     scene.config = patch.config ?? scene.config
-    if (rendersDifferently) scene.version += 1
+
+    /**
+     * Any change bumps the version, a rename included — the control plane
+     * diffs on `scene_id` + `version` (docs/adr/0019-cadence-portee-par-la-scene.md)
+     * and an occasional diff over a field it ignores is cheaper than the
+     * bookkeeping needed to avoid it.
+     *
+     * Lucid answers "did anything change" by deep-comparing the attributes
+     * against the loaded row, so a client repeating the whole form on every
+     * save — the edit sheet does — bumps nothing until a value really moves.
+     * Read before `save()`, which resets the tracking.
+     */
+    const modified = scene.$isDirty
 
     await scene.save()
+
+    /**
+     * Incremented in SQL rather than read-modify-written in JS: two patches
+     * racing on the same scene would both read the same version and write the
+     * same successor, and the lost bump leaves every renderer serving a stale
+     * scene until the next change. Reload so the response carries the version
+     * the database settled on.
+     */
+    if (modified) {
+      await Scene.query().where('id', scene.id).increment('version', 1)
+      await scene.refresh()
+    }
 
     return scene
   }

--- a/webapp/apps/backend/app/transformers/scene_transformer.ts
+++ b/webapp/apps/backend/app/transformers/scene_transformer.ts
@@ -1,0 +1,19 @@
+import { BaseTransformer } from '@adonisjs/core/transformers'
+import type Scene from '#models/scene'
+
+export default class SceneTransformer extends BaseTransformer<Scene> {
+  toObject() {
+    return this.pick(this.resource, [
+      'id',
+      'name',
+      'userId',
+      'width',
+      'height',
+      'targetFps',
+      'config',
+      'version',
+      'createdAt',
+      'updatedAt',
+    ])
+  }
+}

--- a/webapp/apps/backend/app/validators/scene.ts
+++ b/webapp/apps/backend/app/validators/scene.ts
@@ -1,0 +1,89 @@
+import vine from '@vinejs/vine'
+import type { Infer } from '@vinejs/vine/types'
+
+const name = () => vine.string().minLength(3).maxLength(100)
+const dimension = () => vine.number().positive().withoutDecimals()
+const targetFps = () => vine.number().min(1).max(60)
+
+/**
+ * The node catalogue is intentionally open (docs/DATA-MODEL.md § Scene): no
+ * primitive exists yet. A node is only required to be a tagged object — every
+ * future primitive discriminates on `type`, the rest of its shape is unknown
+ * to this envelope on purpose, so adding a primitive never requires touching
+ * it.
+ */
+const sceneNode = () => vine.object({ type: vine.string().minLength(1) }).allowUnknownProperties()
+
+export const sceneConfigSchema = vine.object({
+  version: vine.literal(1),
+  nodes: vine.array(sceneNode()),
+})
+
+export const sceneConfigValidator = vine.compile(sceneConfigSchema)
+
+export type SceneConfig = Infer<typeof sceneConfigSchema>
+
+/**
+ * `width` and `height` are independently optional on a patch, so this rule
+ * only ever runs where both are guaranteed present: on create, and again in
+ * SceneService.patchScene against the row's merged geometry. It cannot live
+ * solely on `patchSceneValidator`, which never sees the unpatched sibling
+ * field.
+ */
+const boundedByProtocolMaximum = vine.createRule<undefined>((value, _options, field) => {
+  const { width, height } = value as { width: number; height: number }
+
+  if (width * height > 65536) {
+    field.report(
+      'The scene geometry ({{ width }}x{{ height }}) exceeds the protocol maximum of 65536 pixels',
+      'boundedByProtocolMaximum',
+      field
+    )
+  }
+})
+
+export const sceneGeometrySchema = vine
+  .object({
+    width: dimension(),
+    height: dimension(),
+  })
+  .use(boundedByProtocolMaximum())
+
+/**
+ * `version` on the row and `status`-like observed fields don't exist on
+ * Scene: everything here is genuinely settable by the owner.
+ */
+export const showSceneValidator = vine.create({
+  params: vine.object({
+    id: vine.string().uuid(),
+  }),
+})
+
+export const createSceneValidator = vine.create(
+  vine
+    .object({
+      name: name(),
+      width: dimension(),
+      height: dimension(),
+      targetFps: targetFps().optional(),
+      config: sceneConfigSchema.optional(),
+    })
+    .use(boundedByProtocolMaximum())
+)
+
+export const patchSceneValidator = vine.create({
+  params: vine.object({
+    id: vine.string().uuid(),
+  }),
+  name: name().optional(),
+  width: dimension().optional(),
+  height: dimension().optional(),
+  targetFps: targetFps().optional(),
+  config: sceneConfigSchema.optional(),
+})
+
+export const deleteSceneValidator = vine.create({
+  params: vine.object({
+    id: vine.string().uuid(),
+  }),
+})

--- a/webapp/apps/backend/app/validators/scene.ts
+++ b/webapp/apps/backend/app/validators/scene.ts
@@ -1,3 +1,4 @@
+import { PROTOCOL_MAXIMUM_PIXELS } from '#constants/scene'
 import vine from '@vinejs/vine'
 import type { Infer } from '@vinejs/vine/types'
 
@@ -14,14 +15,18 @@ const targetFps = () => vine.number().min(1).max(60)
  */
 const sceneNode = () => vine.object({ type: vine.string().minLength(1) }).allowUnknownProperties()
 
-export const sceneConfigSchema = vine.object({
-  version: vine.literal(1),
-  nodes: vine.array(sceneNode()),
-})
+/**
+ * A factory, like every other reusable piece here: a schema instance carries
+ * the rules applied to it, so sharing one across validators shares state that
+ * is meant to be per-validator.
+ */
+const sceneConfig = () =>
+  vine.object({
+    version: vine.literal(1),
+    nodes: vine.array(sceneNode()),
+  })
 
-export const sceneConfigValidator = vine.compile(sceneConfigSchema)
-
-export type SceneConfig = Infer<typeof sceneConfigSchema>
+export type SceneConfig = Infer<ReturnType<typeof sceneConfig>>
 
 /**
  * `width` and `height` are independently optional on a patch, so this rule
@@ -33,21 +38,28 @@ export type SceneConfig = Infer<typeof sceneConfigSchema>
 const boundedByProtocolMaximum = vine.createRule<undefined>((value, _options, field) => {
   const { width, height } = value as { width: number; height: number }
 
-  if (width * height > 65536) {
+  if (width * height > PROTOCOL_MAXIMUM_PIXELS) {
     field.report(
-      'The scene geometry ({{ width }}x{{ height }}) exceeds the protocol maximum of 65536 pixels',
+      'The scene geometry ({{ width }}x{{ height }}) exceeds the protocol maximum of {{ maximum }} pixels',
       'boundedByProtocolMaximum',
-      field
+      field,
+      { width, height, maximum: PROTOCOL_MAXIMUM_PIXELS }
     )
   }
 })
 
-export const sceneGeometrySchema = vine
+const sceneGeometrySchema = vine
   .object({
     width: dimension(),
     height: dimension(),
   })
   .use(boundedByProtocolMaximum())
+
+/**
+ * Compiled once: `vine.validate({ schema })` rebuilds the validation function
+ * on every call, and SceneService re-runs this on every geometry patch.
+ */
+export const sceneGeometryValidator = vine.compile(sceneGeometrySchema)
 
 /**
  * `version` on the row and `status`-like observed fields don't exist on
@@ -66,7 +78,7 @@ export const createSceneValidator = vine.create(
       width: dimension(),
       height: dimension(),
       targetFps: targetFps().optional(),
-      config: sceneConfigSchema.optional(),
+      config: sceneConfig().optional(),
     })
     .use(boundedByProtocolMaximum())
 )
@@ -79,7 +91,7 @@ export const patchSceneValidator = vine.create({
   width: dimension().optional(),
   height: dimension().optional(),
   targetFps: targetFps().optional(),
-  config: sceneConfigSchema.optional(),
+  config: sceneConfig().optional(),
 })
 
 export const deleteSceneValidator = vine.create({

--- a/webapp/apps/backend/app/validators/scene.ts
+++ b/webapp/apps/backend/app/validators/scene.ts
@@ -56,10 +56,11 @@ const sceneGeometrySchema = vine
   .use(boundedByProtocolMaximum())
 
 /**
- * Compiled once: `vine.validate({ schema })` rebuilds the validation function
- * on every call, and SceneService re-runs this on every geometry patch.
+ * Pre-compiled once: `vine.validate({ schema })` rebuilds the validation
+ * function on every call, and SceneService re-runs this on every geometry
+ * patch.
  */
-export const sceneGeometryValidator = vine.compile(sceneGeometrySchema)
+export const sceneGeometryValidator = vine.create(sceneGeometrySchema)
 
 /**
  * `version` on the row and `status`-like observed fields don't exist on

--- a/webapp/apps/backend/database/migrations/1788276883686_create_scenes_table.ts
+++ b/webapp/apps/backend/database/migrations/1788276883686_create_scenes_table.ts
@@ -1,0 +1,53 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'scenes'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.string('id').notNullable().primary()
+
+      table.string('user_id').notNullable()
+      table.foreign('user_id').references('users.id').onDelete('CASCADE')
+
+      table.string('name').notNullable()
+
+      /**
+       * The geometry a scene is authored for, not the device it ends up on
+       * (docs/adr/0018-geometrie-native-de-la-scene.md).
+       */
+      table.integer('width').notNullable()
+      table.integer('height').notNullable()
+
+      table.integer('target_fps').notNullable().defaultTo(30)
+
+      /**
+       * Versioned, validated envelope — see app/validators/scene.ts. Not the
+       * same "version" as the column below: this one is the envelope format's
+       * own version, bumped only if the shape of `config` itself changes.
+       */
+      table.jsonb('config').notNullable()
+
+      /**
+       * Row revision, bumped by SceneService on every render-relevant change.
+       * The control plane diffs on `scene_id` + this column
+       * (docs/adr/0019-cadence-portee-par-la-scene.md).
+       */
+      table.integer('version').notNullable().defaultTo(1)
+
+      table.timestamp('created_at', { useTz: true }).notNullable()
+      table.timestamp('updated_at', { useTz: true }).nullable()
+    })
+
+    this.schema.raw(
+      `ALTER TABLE ${this.tableName} ADD CONSTRAINT scenes_geometry_bounded_check CHECK (width * height <= 65536)`
+    )
+    this.schema.raw(
+      `ALTER TABLE ${this.tableName} ADD CONSTRAINT scenes_target_fps_bounded_check CHECK (target_fps BETWEEN 1 AND 60)`
+    )
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/webapp/apps/backend/database/migrations/1788276883686_create_scenes_table.ts
+++ b/webapp/apps/backend/database/migrations/1788276883686_create_scenes_table.ts
@@ -10,6 +10,12 @@ export default class extends BaseSchema {
       table.string('user_id').notNullable()
       table.foreign('user_id').references('users.id').onDelete('CASCADE')
 
+      /**
+       * Every listing is scoped to one owner, and a foreign key creates no
+       * index of its own in PostgreSQL.
+       */
+      table.index(['user_id'], 'scenes_user_id_index')
+
       table.string('name').notNullable()
 
       /**
@@ -29,7 +35,7 @@ export default class extends BaseSchema {
       table.jsonb('config').notNullable()
 
       /**
-       * Row revision, bumped by SceneService on every render-relevant change.
+       * Row revision, bumped by SceneService on every change.
        * The control plane diffs on `scene_id` + this column
        * (docs/adr/0019-cadence-portee-par-la-scene.md).
        */
@@ -39,6 +45,11 @@ export default class extends BaseSchema {
       table.timestamp('updated_at', { useTz: true }).nullable()
     })
 
+    /**
+     * The literals mirror `PROTOCOL_MAXIMUM_PIXELS` and the validator's fps
+     * bounds on purpose: a migration is a snapshot of the schema at its date
+     * and must not move when an application constant does.
+     */
     this.schema.raw(
       `ALTER TABLE ${this.tableName} ADD CONSTRAINT scenes_geometry_bounded_check CHECK (width * height <= 65536)`
     )

--- a/webapp/apps/backend/database/schema.ts
+++ b/webapp/apps/backend/database/schema.ts
@@ -6,6 +6,7 @@
 
 import { BaseModel, column } from '@adonisjs/lucid/orm'
 import { DateTime } from 'luxon'
+import type { SceneConfig } from '#validators/scene'
 
 export class MatrixSchema extends BaseModel {
   static $columns = [
@@ -80,6 +81,42 @@ export class RendererSchema extends BaseModel {
   declare updatedAt: DateTime | null
   @column()
   declare version: string | null
+}
+
+export class SceneSchema extends BaseModel {
+  static $columns = [
+    'config',
+    'createdAt',
+    'height',
+    'id',
+    'name',
+    'targetFps',
+    'updatedAt',
+    'userId',
+    'version',
+    'width',
+  ] as const
+  $columns = SceneSchema.$columns
+  @column()
+  declare config: SceneConfig
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+  @column()
+  declare height: number
+  @column({ isPrimary: true })
+  declare id: string
+  @column()
+  declare name: string
+  @column()
+  declare targetFps: number
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime | null
+  @column()
+  declare userId: string
+  @column()
+  declare version: number
+  @column()
+  declare width: number
 }
 
 export class UserSchema extends BaseModel {

--- a/webapp/apps/backend/database/schema_rules.ts
+++ b/webapp/apps/backend/database/schema_rules.ts
@@ -23,5 +23,18 @@ export default {
         },
       },
     },
+    scenes: {
+      columns: {
+        /**
+         * The generator can't infer the versioned envelope from a jsonb
+         * column; this keeps `Scene.config` typed instead of `any`.
+         */
+        config: {
+          tsType: 'SceneConfig',
+          decorators: [{ name: '@column' }],
+          imports: [{ source: '#validators/scene', typeImports: ['SceneConfig'] }],
+        },
+      },
+    },
   },
 } satisfies SchemaRules

--- a/webapp/apps/backend/package.json
+++ b/webapp/apps/backend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "MIT",
   "exports": {
+    "./constants/scene": "./app/constants/scene.ts",
     "./data": "./.adonisjs/client/data.d.ts",
     "./registry": "./.adonisjs/client/registry/index.ts"
   },
@@ -18,6 +19,7 @@
     "typecheck": "tsc --noEmit"
   },
   "imports": {
+    "#constants/*": "./app/constants/*.js",
     "#controllers/*": "./app/controllers/*.js",
     "#exceptions/*": "./app/exceptions/*.js",
     "#models/*": "./app/models/*.js",

--- a/webapp/apps/backend/start/routes.ts
+++ b/webapp/apps/backend/start/routes.ts
@@ -58,5 +58,17 @@ router
       .prefix('renderers')
       .as('renderers')
       .use(middleware.auth())
+
+    router
+      .group(() => {
+        router.get('/', [controllers.Scenes, 'index']).as('index')
+        router.get('/:id', [controllers.Scenes, 'show']).as('show')
+        router.post('/', [controllers.Scenes, 'store']).as('store')
+        router.patch('/:id', [controllers.Scenes, 'patch']).as('patch')
+        router.delete('/:id', [controllers.Scenes, 'delete']).as('delete')
+      })
+      .prefix('scenes')
+      .as('scenes')
+      .use(middleware.auth())
   })
   .prefix('/api/v1')

--- a/webapp/apps/backend/tests/functional/scenes.spec.ts
+++ b/webapp/apps/backend/tests/functional/scenes.spec.ts
@@ -1,0 +1,206 @@
+import Scene from '#models/scene'
+import User from '#models/user'
+import { test } from '@japa/runner'
+
+interface ScenePayload {
+  id: string
+  name: string
+  userId: string
+  width: number
+  height: number
+  targetFps: number
+  config: { version: 1; nodes: unknown[] }
+  version: number
+}
+
+function sceneFrom(body: unknown) {
+  return (body as { data: ScenePayload }).data
+}
+
+function scenesFrom(body: unknown) {
+  return (body as { data: ScenePayload[] }).data
+}
+
+let sequence = 0
+
+async function createUser() {
+  sequence += 1
+
+  return User.create({
+    fullName: 'Ada Lovelace',
+    email: `ada-${sequence}@example.test`,
+    password: 'secret123',
+  })
+}
+
+test.group('Scenes', () => {
+  test('rejects a config without a version field', async ({ client }) => {
+    const user = await createUser()
+
+    const response = await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Clock', width: 64, height: 32, config: { nodes: [] } })
+      .loginAs(user)
+
+    response.assertStatus(422)
+  })
+
+  test('rejects a node without a type', async ({ client }) => {
+    const user = await createUser()
+
+    const response = await client
+      .post('/api/v1/scenes')
+      .json({
+        name: 'Clock',
+        width: 64,
+        height: 32,
+        config: { version: 1, nodes: [{ gifName: 'pacman' }] },
+      })
+      .loginAs(user)
+
+    response.assertStatus(422)
+  })
+
+  test('rejects a geometry above the protocol maximum', async ({ client }) => {
+    const user = await createUser()
+
+    const response = await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Too big', width: 300, height: 300 })
+      .loginAs(user)
+
+    response.assertStatus(422)
+  })
+
+  test('defaults targetFps and config when omitted', async ({ client, assert }) => {
+    const user = await createUser()
+
+    const response = await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Clock', width: 64, height: 32 })
+      .loginAs(user)
+
+    response.assertStatus(201)
+
+    const created = sceneFrom(response.body())
+    assert.equal(created.targetFps, 30)
+    assert.deepEqual(created.config, { version: 1, nodes: [] })
+    assert.equal(created.version, 1)
+  })
+
+  test('bounds targetFps to 1..60', async ({ client }) => {
+    const user = await createUser()
+
+    const tooLow = await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Clock', width: 64, height: 32, targetFps: 0 })
+      .loginAs(user)
+
+    const tooHigh = await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Clock', width: 64, height: 32, targetFps: 61 })
+      .loginAs(user)
+
+    tooLow.assertStatus(422)
+    tooHigh.assertStatus(422)
+  })
+
+  test('lists only the caller own scenes', async ({ client, assert }) => {
+    const owner = await createUser()
+    const stranger = await createUser()
+
+    await client.post('/api/v1/scenes').json({ name: 'Mine', width: 64, height: 32 }).loginAs(owner)
+    await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Theirs', width: 64, height: 32 })
+      .loginAs(stranger)
+
+    const response = await client.get('/api/v1/scenes').loginAs(owner)
+
+    response.assertStatus(200)
+    const scenes = scenesFrom(response.body())
+    assert.lengthOf(scenes, 1)
+    assert.equal(scenes[0]!.name, 'Mine')
+  })
+
+  test('hides the scenes of other users', async ({ client }) => {
+    const owner = await createUser()
+    const stranger = await createUser()
+
+    const creation = await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Mine', width: 64, height: 32 })
+      .loginAs(owner)
+
+    const scene = sceneFrom(creation.body())
+
+    const show = await client.get(`/api/v1/scenes/${scene.id}`).loginAs(stranger)
+    const patch = await client
+      .patch(`/api/v1/scenes/${scene.id}`)
+      .json({ name: 'Stolen' })
+      .loginAs(stranger)
+    const destroy = await client.delete(`/api/v1/scenes/${scene.id}`).loginAs(stranger)
+
+    show.assertStatus(403)
+    patch.assertStatus(403)
+    destroy.assertStatus(403)
+  })
+
+  test('bumps version when config changes, not when only the name does', async ({
+    client,
+    assert,
+  }) => {
+    const user = await createUser()
+
+    const creation = await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Clock', width: 64, height: 32 })
+      .loginAs(user)
+
+    const scene = sceneFrom(creation.body())
+
+    const renamed = await client
+      .patch(`/api/v1/scenes/${scene.id}`)
+      .json({ name: 'Renamed' })
+      .loginAs(user)
+
+    assert.equal(sceneFrom(renamed.body()).version, 1)
+
+    const reconfigured = await client
+      .patch(`/api/v1/scenes/${scene.id}`)
+      .json({ config: { version: 1, nodes: [{ type: 'text' }] } })
+      .loginAs(user)
+
+    assert.equal(sceneFrom(reconfigured.body()).version, 2)
+  })
+
+  test('rejects a patch that would push a merged geometry past the maximum', async ({
+    client,
+    assert,
+  }) => {
+    const user = await createUser()
+
+    const creation = await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Clock', width: 64, height: 32 })
+      .loginAs(user)
+
+    const scene = sceneFrom(creation.body())
+
+    const response = await client
+      .patch(`/api/v1/scenes/${scene.id}`)
+      .json({ width: 2049 })
+      .loginAs(user)
+
+    response.assertStatus(422)
+
+    const stored = await Scene.findOrFail(scene.id)
+    assert.equal(stored.width, 64)
+  })
+
+  test('requires an authenticated user', async ({ client }) => {
+    const response = await client.get('/api/v1/scenes')
+
+    response.assertStatus(401)
+  })
+})

--- a/webapp/apps/backend/tests/functional/scenes.spec.ts
+++ b/webapp/apps/backend/tests/functional/scenes.spec.ts
@@ -61,7 +61,7 @@ test.group('Scenes', () => {
     response.assertStatus(422)
   })
 
-  test('rejects a geometry above the protocol maximum', async ({ client }) => {
+  test('rejects a geometry above the protocol maximum', async ({ client, assert }) => {
     const user = await createUser()
 
     const response = await client
@@ -70,6 +70,9 @@ test.group('Scenes', () => {
       .loginAs(user)
 
     response.assertStatus(422)
+
+    const [failure] = (response.body() as unknown as { errors: { message: string }[] }).errors
+    assert.include(failure!.message, '300x300')
   })
 
   test('defaults targetFps and config when omitted', async ({ client, assert }) => {
@@ -146,10 +149,7 @@ test.group('Scenes', () => {
     destroy.assertStatus(403)
   })
 
-  test('bumps version when config changes, not when only the name does', async ({
-    client,
-    assert,
-  }) => {
+  test('bumps version on every change, a rename included', async ({ client, assert }) => {
     const user = await createUser()
 
     const creation = await client
@@ -164,14 +164,43 @@ test.group('Scenes', () => {
       .json({ name: 'Renamed' })
       .loginAs(user)
 
-    assert.equal(sceneFrom(renamed.body()).version, 1)
+    assert.equal(sceneFrom(renamed.body()).version, 2)
 
     const reconfigured = await client
       .patch(`/api/v1/scenes/${scene.id}`)
       .json({ config: { version: 1, nodes: [{ type: 'text' }] } })
       .loginAs(user)
 
-    assert.equal(sceneFrom(reconfigured.body()).version, 2)
+    assert.equal(sceneFrom(reconfigured.body()).version, 3)
+  })
+
+  test('leaves version alone when a patch changes nothing', async ({ client, assert }) => {
+    const user = await createUser()
+
+    const creation = await client
+      .post('/api/v1/scenes')
+      .json({ name: 'Clock', width: 64, height: 32, targetFps: 30 })
+      .loginAs(user)
+
+    const scene = sceneFrom(creation.body())
+
+    /**
+     * The edit sheet submits every field it renders, not only the dirty ones,
+     * so resubmitting an untouched form must not inflate the version. The
+     * `config` envelope is compared by value too, not by identity.
+     */
+    const resubmitted = await client
+      .patch(`/api/v1/scenes/${scene.id}`)
+      .json({
+        name: 'Clock',
+        width: 64,
+        height: 32,
+        targetFps: 30,
+        config: { version: 1, nodes: [] },
+      })
+      .loginAs(user)
+
+    assert.equal(sceneFrom(resubmitted.body()).version, 1)
   })
 
   test('rejects a patch that would push a merged geometry past the maximum', async ({

--- a/webapp/apps/frontend/app/components/AppSidebar.vue
+++ b/webapp/apps/frontend/app/components/AppSidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { SidebarProps } from '@/components/ui/sidebar'
 
-import { Grid2x2, Server, Tv2 } from 'lucide-vue-next'
+import { Grid2x2, Layers, Server, Tv2 } from 'lucide-vue-next'
 
 const props = withDefaults(defineProps<SidebarProps>(), {
   collapsible: 'icon',
@@ -27,6 +27,11 @@ const data = computed(() => ({
       title: t('nav.matrices'),
       url: '/',
       icon: Grid2x2,
+    },
+    {
+      title: t('nav.scenes'),
+      url: '/scenes',
+      icon: Layers,
     },
     {
       title: t('nav.renderers'),

--- a/webapp/apps/frontend/app/components/dialog/scene/delete.vue
+++ b/webapp/apps/frontend/app/components/dialog/scene/delete.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { AlertCircleIcon } from 'lucide-vue-next'
+
+const props = defineProps<{
+  scene: {
+    id: string
+    name: string
+  }
+}>()
+
+const { t } = useI18n()
+const { $api, callHook } = useNuxtApp()
+
+const deleteError = ref<string | null>(null)
+
+const open = ref(false)
+
+async function deleteScene() {
+  deleteError.value = null
+
+  const [_, error] = await $api
+    .request('scenes.delete', {
+      params: { id: props.scene.id },
+    })
+    .safe()
+
+  if (error) {
+    deleteError.value = t('dialogs.deleteScene.failure.unknownDescription')
+    return
+  }
+
+  await callHook('app:scene:deleted', props.scene.id)
+
+  open.value = false
+}
+</script>
+
+<template>
+  <UiAlertDialog v-model:open="open">
+    <UiAlertDialogTrigger asChild>
+      <slot />
+    </UiAlertDialogTrigger>
+    <UiAlertDialogContent>
+      <UiAlertDialogHeader>
+        <UiAlertDialogTitle>
+          {{ t('dialogs.deleteScene.title') }}
+        </UiAlertDialogTitle>
+        <UiAlertDialogDescription>
+          <UiAlert v-if="deleteError" variant="destructive">
+            <AlertCircleIcon />
+            <UiAlertTitle>{{ t('dialogs.deleteScene.failure.title') }}</UiAlertTitle>
+            <UiAlertDescription>
+              {{ deleteError }}
+            </UiAlertDescription>
+          </UiAlert>
+
+          <i18n-t keypath="dialogs.deleteScene.description" scope="global">
+            <span class="font-medium">{{ props.scene.name }}</span>
+          </i18n-t>
+        </UiAlertDialogDescription>
+      </UiAlertDialogHeader>
+      <UiAlertDialogFooter>
+        <UiAlertDialogCancel class="cursor-pointer">
+          {{ t('dialogs.deleteScene.cancel') }}
+        </UiAlertDialogCancel>
+        <UiAlertDialogAction asChild>
+          <UiButton class="cursor-pointer" variant="destructive" @click="deleteScene()">
+            {{ t('dialogs.deleteScene.confirm') }}
+          </UiButton>
+        </UiAlertDialogAction>
+      </UiAlertDialogFooter>
+    </UiAlertDialogContent>
+  </UiAlertDialog>
+</template>

--- a/webapp/apps/frontend/app/components/sheet/scene/create.vue
+++ b/webapp/apps/frontend/app/components/sheet/scene/create.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { PROTOCOL_MAXIMUM_PIXELS } from '@matrixled-ssr/backend/constants/scene'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm } from 'vee-validate'
 import z from 'zod'
@@ -19,8 +20,8 @@ const formSchema = computed(() =>
         height: z.coerce.number().int().min(1),
         targetFps: z.coerce.number().int().min(1).max(60),
       })
-      .refine((values) => values.width * values.height <= 65536, {
-        message: t('sheets.createScene.validation.geometry'),
+      .refine((values) => values.width * values.height <= PROTOCOL_MAXIMUM_PIXELS, {
+        message: t('sheets.createScene.validation.geometry', { max: PROTOCOL_MAXIMUM_PIXELS }),
         path: ['height'],
       })
   )
@@ -129,9 +130,9 @@ const onSubmit = form.handleSubmit(async (values) => {
                 <UiFormControl>
                   <UiSlider
                     :model-value="[value]"
-                    :min="5"
+                    :min="1"
                     :max="60"
-                    :step="5"
+                    :step="1"
                     @update:model-value="(v) => handleChange(v?.[0] ?? value)"
                   />
                 </UiFormControl>

--- a/webapp/apps/frontend/app/components/sheet/scene/create.vue
+++ b/webapp/apps/frontend/app/components/sheet/scene/create.vue
@@ -87,57 +87,55 @@ const onSubmit = form.handleSubmit(async (values) => {
               </UiFormItem>
             </UiFormField>
 
-            <UiFormField v-slot="{ componentField }" name="width">
-              <UiFormItem>
-                <UiFormControl>
-                  <UiNumberField v-bind="componentField" :defaultValue="64" :min="1" :step="1">
-                    <UiFormLabel>{{ t('sheets.createScene.fields.width') }}</UiFormLabel>
-                    <UiNumberFieldContent>
-                      <UiNumberFieldDecrement />
-                      <UiNumberFieldInput />
-                      <UiNumberFieldIncrement />
-                    </UiNumberFieldContent>
-                    <UiFormMessage />
-                  </UiNumberField>
-                </UiFormControl>
-              </UiFormItem>
-            </UiFormField>
+            <div class="grid grid-cols-2 gap-4">
+              <UiFormField v-slot="{ componentField }" name="width">
+                <UiFormItem>
+                  <UiFormControl>
+                    <UiNumberField v-bind="componentField" :defaultValue="64" :min="1" :step="1">
+                      <UiFormLabel>{{ t('sheets.createScene.fields.width') }}</UiFormLabel>
+                      <UiNumberFieldContent>
+                        <UiNumberFieldDecrement />
+                        <UiNumberFieldInput />
+                        <UiNumberFieldIncrement />
+                      </UiNumberFieldContent>
+                      <UiFormMessage />
+                    </UiNumberField>
+                  </UiFormControl>
+                </UiFormItem>
+              </UiFormField>
 
-            <UiFormField v-slot="{ componentField }" name="height">
-              <UiFormItem>
-                <UiFormControl>
-                  <UiNumberField v-bind="componentField" :defaultValue="32" :min="1" :step="1">
-                    <UiFormLabel>{{ t('sheets.createScene.fields.height') }}</UiFormLabel>
-                    <UiNumberFieldContent>
-                      <UiNumberFieldDecrement />
-                      <UiNumberFieldInput />
-                      <UiNumberFieldIncrement />
-                    </UiNumberFieldContent>
-                    <UiFormMessage />
-                  </UiNumberField>
-                </UiFormControl>
-              </UiFormItem>
-            </UiFormField>
+              <UiFormField v-slot="{ componentField }" name="height">
+                <UiFormItem>
+                  <UiFormControl>
+                    <UiNumberField v-bind="componentField" :defaultValue="32" :min="1" :step="1">
+                      <UiFormLabel>{{ t('sheets.createScene.fields.height') }}</UiFormLabel>
+                      <UiNumberFieldContent>
+                        <UiNumberFieldDecrement />
+                        <UiNumberFieldInput />
+                        <UiNumberFieldIncrement />
+                      </UiNumberFieldContent>
+                      <UiFormMessage />
+                    </UiNumberField>
+                  </UiFormControl>
+                </UiFormItem>
+              </UiFormField>
+            </div>
 
-            <UiFormField v-slot="{ componentField }" name="targetFps">
+            <UiFormField v-slot="{ value, handleChange }" name="targetFps">
               <UiFormItem>
+                <UiFormLabel>
+                  {{ t('sheets.createScene.fields.targetFps') }} ({{ value }})
+                </UiFormLabel>
                 <UiFormControl>
-                  <UiNumberField
-                    v-bind="componentField"
-                    :defaultValue="30"
-                    :min="1"
+                  <UiSlider
+                    :model-value="[value]"
+                    :min="5"
                     :max="60"
-                    :step="1"
-                  >
-                    <UiFormLabel>{{ t('sheets.createScene.fields.targetFps') }}</UiFormLabel>
-                    <UiNumberFieldContent>
-                      <UiNumberFieldDecrement />
-                      <UiNumberFieldInput />
-                      <UiNumberFieldIncrement />
-                    </UiNumberFieldContent>
-                    <UiFormMessage />
-                  </UiNumberField>
+                    :step="5"
+                    @update:model-value="(v) => handleChange(v?.[0] ?? value)"
+                  />
                 </UiFormControl>
+                <UiFormMessage />
               </UiFormItem>
             </UiFormField>
           </div>

--- a/webapp/apps/frontend/app/components/sheet/scene/create.vue
+++ b/webapp/apps/frontend/app/components/sheet/scene/create.vue
@@ -1,0 +1,170 @@
+<script setup lang="ts">
+import { toTypedSchema } from '@vee-validate/zod'
+import { useForm } from 'vee-validate'
+import z from 'zod'
+
+const { t } = useI18n()
+const { $api, callHook } = useNuxtApp()
+
+const open = ref(false)
+
+const creationError = ref<string | null>(null)
+
+const formSchema = computed(() =>
+  toTypedSchema(
+    z
+      .object({
+        name: z.string().min(3).max(100),
+        width: z.coerce.number().int().min(1),
+        height: z.coerce.number().int().min(1),
+        targetFps: z.coerce.number().int().min(1).max(60),
+      })
+      .refine((values) => values.width * values.height <= 65536, {
+        message: t('sheets.createScene.validation.geometry'),
+        path: ['height'],
+      })
+  )
+)
+
+const form = useForm({
+  validationSchema: formSchema,
+  initialValues: {
+    name: '',
+    width: 64,
+    height: 32,
+    targetFps: 30,
+  },
+})
+
+const onSubmit = form.handleSubmit(async (values) => {
+  creationError.value = null
+
+  const [data, error] = await $api
+    .request('scenes.store', {
+      body: values,
+    })
+    .safe()
+
+  if (error) {
+    creationError.value = t('sheets.createScene.failure.unknownDescription')
+
+    return
+  }
+
+  form.resetForm()
+
+  await callHook('app:scene:created', data.data)
+
+  open.value = false
+})
+</script>
+
+<template>
+  <UiSheet v-model:open="open">
+    <UiSheetTrigger asChild>
+      <slot />
+    </UiSheetTrigger>
+    <UiSheetContent>
+      <UiSheetHeader>
+        <UiSheetTitle>{{ t('sheets.createScene.title') }}</UiSheetTitle>
+      </UiSheetHeader>
+
+      <div class="grid flex-1 auto-rows-min gap-6 px-4">
+        <UiAlert v-if="creationError" variant="destructive">
+          <UiAlertTitle>{{ t('sheets.createScene.failure.title') }}</UiAlertTitle>
+          <UiAlertDescription>{{ creationError }}</UiAlertDescription>
+        </UiAlert>
+
+        <form @submit.prevent="onSubmit" id="create-scene-form">
+          <div class="grid flex-1 auto-rows-min gap-6">
+            <UiFormField v-slot="{ componentField }" name="name">
+              <UiFormItem>
+                <UiFormLabel>{{ t('sheets.createScene.fields.name') }}</UiFormLabel>
+                <UiFormControl>
+                  <UiInput v-bind="componentField" />
+                </UiFormControl>
+                <UiFormMessage />
+              </UiFormItem>
+            </UiFormField>
+
+            <UiFormField v-slot="{ componentField }" name="width">
+              <UiFormItem>
+                <UiFormControl>
+                  <UiNumberField v-bind="componentField" :defaultValue="64" :min="1" :step="1">
+                    <UiFormLabel>{{ t('sheets.createScene.fields.width') }}</UiFormLabel>
+                    <UiNumberFieldContent>
+                      <UiNumberFieldDecrement />
+                      <UiNumberFieldInput />
+                      <UiNumberFieldIncrement />
+                    </UiNumberFieldContent>
+                    <UiFormMessage />
+                  </UiNumberField>
+                </UiFormControl>
+              </UiFormItem>
+            </UiFormField>
+
+            <UiFormField v-slot="{ componentField }" name="height">
+              <UiFormItem>
+                <UiFormControl>
+                  <UiNumberField v-bind="componentField" :defaultValue="32" :min="1" :step="1">
+                    <UiFormLabel>{{ t('sheets.createScene.fields.height') }}</UiFormLabel>
+                    <UiNumberFieldContent>
+                      <UiNumberFieldDecrement />
+                      <UiNumberFieldInput />
+                      <UiNumberFieldIncrement />
+                    </UiNumberFieldContent>
+                    <UiFormMessage />
+                  </UiNumberField>
+                </UiFormControl>
+              </UiFormItem>
+            </UiFormField>
+
+            <UiFormField v-slot="{ componentField }" name="targetFps">
+              <UiFormItem>
+                <UiFormControl>
+                  <UiNumberField
+                    v-bind="componentField"
+                    :defaultValue="30"
+                    :min="1"
+                    :max="60"
+                    :step="1"
+                  >
+                    <UiFormLabel>{{ t('sheets.createScene.fields.targetFps') }}</UiFormLabel>
+                    <UiNumberFieldContent>
+                      <UiNumberFieldDecrement />
+                      <UiNumberFieldInput />
+                      <UiNumberFieldIncrement />
+                    </UiNumberFieldContent>
+                    <UiFormMessage />
+                  </UiNumberField>
+                </UiFormControl>
+              </UiFormItem>
+            </UiFormField>
+          </div>
+        </form>
+      </div>
+
+      <UiSheetFooter>
+        <UiButton
+          type="submit"
+          form="create-scene-form"
+          class="w-full"
+          :disabled="!form.meta.value.valid || form.meta.value.pending"
+        >
+          <template v-if="form.meta.value.pending">
+            <UiSpinner class="animate-spin" />
+          </template>
+          <template v-else>
+            {{ t('sheets.createScene.submit') }}
+          </template>
+        </UiButton>
+
+        <UiSheetClose as-child>
+          <UiButton variant="outline">
+            {{ t('sheets.createScene.cancel') }}
+          </UiButton>
+        </UiSheetClose>
+      </UiSheetFooter>
+    </UiSheetContent>
+  </UiSheet>
+</template>

--- a/webapp/apps/frontend/app/components/sheet/scene/edit.vue
+++ b/webapp/apps/frontend/app/components/sheet/scene/edit.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { PROTOCOL_MAXIMUM_PIXELS } from '@matrixled-ssr/backend/constants/scene'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm } from 'vee-validate'
 import z from 'zod'
@@ -29,8 +30,8 @@ const formSchema = computed(() =>
         height: z.coerce.number().int().min(1),
         targetFps: z.coerce.number().int().min(1).max(60),
       })
-      .refine((values) => values.width * values.height <= 65536, {
-        message: t('sheets.editScene.validation.geometry'),
+      .refine((values) => values.width * values.height <= PROTOCOL_MAXIMUM_PIXELS, {
+        message: t('sheets.editScene.validation.geometry', { max: PROTOCOL_MAXIMUM_PIXELS }),
         path: ['height'],
       })
   )
@@ -150,9 +151,9 @@ const onSubmit = form.handleSubmit(async (values) => {
                 <UiFormControl>
                   <UiSlider
                     :model-value="[value]"
-                    :min="5"
+                    :min="1"
                     :max="60"
-                    :step="5"
+                    :step="1"
                     @update:model-value="(v) => handleChange(v?.[0] ?? value)"
                   />
                 </UiFormControl>

--- a/webapp/apps/frontend/app/components/sheet/scene/edit.vue
+++ b/webapp/apps/frontend/app/components/sheet/scene/edit.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { toTypedSchema } from '@vee-validate/zod'
+import { useForm } from 'vee-validate'
+import z from 'zod'
+
+const props = defineProps<{
+  scene: {
+    id: string
+    name: string
+    width: number
+    height: number
+    targetFps: number
+  }
+}>()
+
+const { t } = useI18n()
+const { $api, callHook } = useNuxtApp()
+
+const open = ref(false)
+
+const editionError = ref<string | null>(null)
+
+const formSchema = computed(() =>
+  toTypedSchema(
+    z
+      .object({
+        name: z.string().min(3).max(100),
+        width: z.coerce.number().int().min(1),
+        height: z.coerce.number().int().min(1),
+        targetFps: z.coerce.number().int().min(1).max(60),
+      })
+      .refine((values) => values.width * values.height <= 65536, {
+        message: t('sheets.editScene.validation.geometry'),
+        path: ['height'],
+      })
+  )
+)
+
+const form = useForm({
+  validationSchema: formSchema,
+  initialValues: {
+    name: props.scene.name,
+    width: props.scene.width,
+    height: props.scene.height,
+    targetFps: props.scene.targetFps,
+  },
+})
+
+watch(
+  () => props.scene,
+  (scene) => {
+    form.setValues({
+      name: scene.name,
+      width: scene.width,
+      height: scene.height,
+      targetFps: scene.targetFps,
+    })
+  }
+)
+
+const onSubmit = form.handleSubmit(async (values) => {
+  editionError.value = null
+
+  const [data, error] = await $api
+    .request('scenes.patch', {
+      params: { id: props.scene.id },
+      body: values,
+    })
+    .safe()
+
+  if (error) {
+    editionError.value = t('sheets.editScene.failure.unknownDescription')
+
+    return
+  }
+
+  await callHook('app:scene:updated', data.data)
+
+  open.value = false
+})
+</script>
+
+<template>
+  <UiSheet v-model:open="open">
+    <UiSheetTrigger asChild>
+      <slot />
+    </UiSheetTrigger>
+    <UiSheetContent>
+      <UiSheetHeader>
+        <UiSheetTitle>{{ t('sheets.editScene.title') }}</UiSheetTitle>
+      </UiSheetHeader>
+
+      <div class="grid flex-1 auto-rows-min gap-6 px-4">
+        <UiAlert v-if="editionError" variant="destructive">
+          <UiAlertTitle>{{ t('sheets.editScene.failure.title') }}</UiAlertTitle>
+          <UiAlertDescription>{{ editionError }}</UiAlertDescription>
+        </UiAlert>
+
+        <form @submit.prevent="onSubmit" id="edit-scene-form">
+          <div class="grid flex-1 auto-rows-min gap-6">
+            <UiFormField v-slot="{ componentField }" name="name">
+              <UiFormItem>
+                <UiFormLabel>{{ t('sheets.editScene.fields.name') }}</UiFormLabel>
+                <UiFormControl>
+                  <UiInput v-bind="componentField" />
+                </UiFormControl>
+                <UiFormMessage />
+              </UiFormItem>
+            </UiFormField>
+
+            <div class="grid grid-cols-2 gap-4">
+              <UiFormField v-slot="{ componentField }" name="width">
+                <UiFormItem>
+                  <UiFormControl>
+                    <UiNumberField v-bind="componentField" :min="1" :step="1">
+                      <UiFormLabel>{{ t('sheets.editScene.fields.width') }}</UiFormLabel>
+                      <UiNumberFieldContent>
+                        <UiNumberFieldDecrement />
+                        <UiNumberFieldInput />
+                        <UiNumberFieldIncrement />
+                      </UiNumberFieldContent>
+                      <UiFormMessage />
+                    </UiNumberField>
+                  </UiFormControl>
+                </UiFormItem>
+              </UiFormField>
+
+              <UiFormField v-slot="{ componentField }" name="height">
+                <UiFormItem>
+                  <UiFormControl>
+                    <UiNumberField v-bind="componentField" :min="1" :step="1">
+                      <UiFormLabel>{{ t('sheets.editScene.fields.height') }}</UiFormLabel>
+                      <UiNumberFieldContent>
+                        <UiNumberFieldDecrement />
+                        <UiNumberFieldInput />
+                        <UiNumberFieldIncrement />
+                      </UiNumberFieldContent>
+                      <UiFormMessage />
+                    </UiNumberField>
+                  </UiFormControl>
+                </UiFormItem>
+              </UiFormField>
+            </div>
+
+            <UiFormField v-slot="{ value, handleChange }" name="targetFps">
+              <UiFormItem>
+                <UiFormLabel>
+                  {{ t('sheets.editScene.fields.targetFps') }} ({{ value }})
+                </UiFormLabel>
+                <UiFormControl>
+                  <UiSlider
+                    :model-value="[value]"
+                    :min="5"
+                    :max="60"
+                    :step="5"
+                    @update:model-value="(v) => handleChange(v?.[0] ?? value)"
+                  />
+                </UiFormControl>
+                <UiFormMessage />
+              </UiFormItem>
+            </UiFormField>
+          </div>
+        </form>
+      </div>
+
+      <UiSheetFooter>
+        <UiButton
+          type="submit"
+          form="edit-scene-form"
+          class="w-full"
+          :disabled="!form.meta.value.valid || form.meta.value.pending"
+        >
+          <template v-if="form.meta.value.pending">
+            <UiSpinner class="animate-spin" />
+          </template>
+          <template v-else>
+            {{ t('sheets.editScene.submit') }}
+          </template>
+        </UiButton>
+
+        <UiSheetClose as-child>
+          <UiButton variant="outline">
+            {{ t('sheets.editScene.cancel') }}
+          </UiButton>
+        </UiSheetClose>
+      </UiSheetFooter>
+    </UiSheetContent>
+  </UiSheet>
+</template>

--- a/webapp/apps/frontend/app/components/ui/slider/Slider.vue
+++ b/webapp/apps/frontend/app/components/ui/slider/Slider.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { SliderRootEmits, SliderRootProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { SliderRange, SliderRoot, SliderThumb, SliderTrack, useForwardPropsEmits } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<SliderRootProps & { class?: HTMLAttributes['class'] }>()
+const emits = defineEmits<SliderRootEmits>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <SliderRoot
+    v-slot="{ modelValue }"
+    data-slot="slider"
+    :class="
+      cn(
+        'relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col',
+        props.class
+      )
+    "
+    v-bind="forwarded"
+  >
+    <SliderTrack
+      data-slot="slider-track"
+      class="bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+    >
+      <SliderRange
+        data-slot="slider-range"
+        class="bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+      />
+    </SliderTrack>
+
+    <SliderThumb
+      v-for="(_, key) in modelValue"
+      :key="key"
+      data-slot="slider-thumb"
+      class="bg-white border-primary ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+    />
+  </SliderRoot>
+</template>

--- a/webapp/apps/frontend/app/components/ui/slider/index.ts
+++ b/webapp/apps/frontend/app/components/ui/slider/index.ts
@@ -1,0 +1,1 @@
+export { default as Slider } from './Slider.vue'

--- a/webapp/apps/frontend/app/hooks.d.ts
+++ b/webapp/apps/frontend/app/hooks.d.ts
@@ -3,6 +3,7 @@ import type { Route } from '@tuyau/core/types'
 
 type MatrixDto = Route.Response<'matrices.store'>['data']
 type RendererDto = Route.Response<'renderers.store'>['data']
+type SceneDto = Route.Response<'scenes.store'>['data']
 
 declare module '#app' {
   interface RuntimeNuxtHooks {
@@ -12,5 +13,8 @@ declare module '#app' {
     'app:renderer:created': (renderer: RendererDto) => HookResult
     'app:renderer:updated': (renderer: RendererDto) => HookResult
     'app:renderer:deleted': (rendererId: RendererDto['id']) => HookResult
+    'app:scene:created': (scene: SceneDto) => HookResult
+    'app:scene:updated': (scene: SceneDto) => HookResult
+    'app:scene:deleted': (sceneId: SceneDto['id']) => HookResult
   }
 }

--- a/webapp/apps/frontend/app/pages/scenes.vue
+++ b/webapp/apps/frontend/app/pages/scenes.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Trash } from 'lucide-vue-next'
+import { Pencil, Trash } from 'lucide-vue-next'
 
 const { t } = useI18n()
 const { $api, hook } = useNuxtApp()
@@ -64,6 +64,17 @@ hook('app:scene:deleted', async () => {
           <UiTableCell>{{ scene.version }}</UiTableCell>
           <UiTableCell class="text-right">
             <div class="flex justify-end gap-2">
+              <SheetSceneEdit :scene="scene">
+                <UiButton
+                  variant="outline"
+                  size="icon"
+                  :aria-label="t('pages.scenes.actions.edit')"
+                  class="cursor-pointer"
+                >
+                  <Pencil />
+                </UiButton>
+              </SheetSceneEdit>
+
               <DialogSceneDelete :scene="scene">
                 <UiButton
                   variant="destructive"

--- a/webapp/apps/frontend/app/pages/scenes.vue
+++ b/webapp/apps/frontend/app/pages/scenes.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { Trash } from 'lucide-vue-next'
+
+const { t } = useI18n()
+const { $api, hook } = useNuxtApp()
+
+const {
+  data: scenes,
+  pending,
+  refresh,
+} = useAsyncData('scenes', async () => {
+  const [data, error] = await $api.request('scenes.index', {}).safe()
+
+  if (error) {
+    return []
+  }
+
+  return data.data
+})
+
+hook('app:scene:created', async () => {
+  await refresh()
+})
+hook('app:scene:updated', async () => {
+  await refresh()
+})
+hook('app:scene:deleted', async () => {
+  await refresh()
+})
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between gap-2">
+      <div class="flex items-center gap-2">
+        <h2 class="text-2xl font-semibold tracking-tight">
+          {{ t('pages.scenes.title') }}
+        </h2>
+        <UiSpinner v-if="pending" />
+        <span v-else class="text-md text-gray-500">({{ scenes?.length ?? 0 }})</span>
+      </div>
+      <SheetSceneCreate>
+        <UiButton>
+          {{ t('pages.scenes.actions.create') }}
+        </UiButton>
+      </SheetSceneCreate>
+    </div>
+
+    <UiTable>
+      <UiTableHeader>
+        <UiTableRow>
+          <UiTableHead>{{ t('pages.scenes.table.name') }}</UiTableHead>
+          <UiTableHead>{{ t('pages.scenes.table.size') }}</UiTableHead>
+          <UiTableHead>{{ t('pages.scenes.table.targetFps') }}</UiTableHead>
+          <UiTableHead>{{ t('pages.scenes.table.version') }}</UiTableHead>
+          <UiTableHead />
+        </UiTableRow>
+      </UiTableHeader>
+      <UiTableBody>
+        <UiTableRow v-for="scene in scenes" :key="scene.id">
+          <UiTableCell>{{ scene.name }}</UiTableCell>
+          <UiTableCell>{{ scene.width }} x {{ scene.height }}</UiTableCell>
+          <UiTableCell>{{ scene.targetFps }}</UiTableCell>
+          <UiTableCell>{{ scene.version }}</UiTableCell>
+          <UiTableCell class="text-right">
+            <div class="flex justify-end gap-2">
+              <DialogSceneDelete :scene="scene">
+                <UiButton
+                  variant="destructive"
+                  size="icon"
+                  :aria-label="t('pages.scenes.actions.delete')"
+                  class="cursor-pointer"
+                >
+                  <Trash />
+                </UiButton>
+              </DialogSceneDelete>
+            </div>
+          </UiTableCell>
+        </UiTableRow>
+      </UiTableBody>
+    </UiTable>
+  </div>
+</template>

--- a/webapp/apps/frontend/i18n/locales/en.json
+++ b/webapp/apps/frontend/i18n/locales/en.json
@@ -148,7 +148,7 @@
         "targetFps": "Target FPS"
       },
       "validation": {
-        "geometry": "The scene geometry exceeds the protocol maximum of 65536 pixels"
+        "geometry": "The scene geometry exceeds the protocol maximum of {max} pixels"
       },
       "submit": "Create",
       "cancel": "Cancel"
@@ -166,7 +166,7 @@
         "targetFps": "Target FPS"
       },
       "validation": {
-        "geometry": "The scene geometry exceeds the protocol maximum of 65536 pixels"
+        "geometry": "The scene geometry exceeds the protocol maximum of {max} pixels"
       },
       "submit": "Save",
       "cancel": "Cancel"

--- a/webapp/apps/frontend/i18n/locales/en.json
+++ b/webapp/apps/frontend/i18n/locales/en.json
@@ -75,6 +75,19 @@
         "delete": "Delete",
         "rotateToken": "Rotate token"
       }
+    },
+    "scenes": {
+      "title": "My scenes",
+      "table": {
+        "name": "Name",
+        "size": "Size (w x h)",
+        "targetFps": "Target FPS",
+        "version": "Version"
+      },
+      "actions": {
+        "create": "New scene",
+        "delete": "Delete"
+      }
     }
   },
   "validation": {
@@ -87,7 +100,8 @@
     "logout": "Log out",
     "platform": "Platform",
     "matrices": "Matrices",
-    "renderers": "Renderers"
+    "renderers": "Renderers",
+    "scenes": "Scenes"
   },
   "app": {
     "name": "Matrix Led SSR",
@@ -119,6 +133,24 @@
       "submit": "Create",
       "cancel": "Cancel",
       "done": "Done"
+    },
+    "createScene": {
+      "title": "Create a scene",
+      "failure": {
+        "title": "Creation failed",
+        "unknownDescription": "An unknown error occurred while trying to create a scene."
+      },
+      "fields": {
+        "name": "Name",
+        "width": "Width (px)",
+        "height": "Height (px)",
+        "targetFps": "Target FPS"
+      },
+      "validation": {
+        "geometry": "The scene geometry exceeds the protocol maximum of 65536 pixels"
+      },
+      "submit": "Create",
+      "cancel": "Cancel"
     }
   },
   "dialogs": {
@@ -151,6 +183,16 @@
       "failure": {
         "title": "Rotation failed",
         "unknownDescription": "An unknown error occurred while trying to rotate the token."
+      }
+    },
+    "deleteScene": {
+      "title": "Delete the scene",
+      "description": "Are you sure you want to delete the scene {0}? This action cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete",
+      "failure": {
+        "title": "Deletion failed",
+        "unknownDescription": "An unknown error occurred while trying to delete the scene."
       }
     }
   },

--- a/webapp/apps/frontend/i18n/locales/en.json
+++ b/webapp/apps/frontend/i18n/locales/en.json
@@ -86,6 +86,7 @@
       },
       "actions": {
         "create": "New scene",
+        "edit": "Edit",
         "delete": "Delete"
       }
     }
@@ -150,6 +151,24 @@
         "geometry": "The scene geometry exceeds the protocol maximum of 65536 pixels"
       },
       "submit": "Create",
+      "cancel": "Cancel"
+    },
+    "editScene": {
+      "title": "Edit the scene",
+      "failure": {
+        "title": "Update failed",
+        "unknownDescription": "An unknown error occurred while trying to update the scene."
+      },
+      "fields": {
+        "name": "Name",
+        "width": "Width (px)",
+        "height": "Height (px)",
+        "targetFps": "Target FPS"
+      },
+      "validation": {
+        "geometry": "The scene geometry exceeds the protocol maximum of 65536 pixels"
+      },
+      "submit": "Save",
       "cancel": "Cancel"
     }
   },

--- a/webapp/apps/frontend/i18n/locales/fr.json
+++ b/webapp/apps/frontend/i18n/locales/fr.json
@@ -148,7 +148,7 @@
         "targetFps": "Cadence cible"
       },
       "validation": {
-        "geometry": "La géométrie de la scène dépasse le maximum du protocole de 65536 pixels"
+        "geometry": "La géométrie de la scène dépasse le maximum du protocole de {max} pixels"
       },
       "submit": "Créer",
       "cancel": "Annuler"
@@ -166,7 +166,7 @@
         "targetFps": "Cadence cible"
       },
       "validation": {
-        "geometry": "La géométrie de la scène dépasse le maximum du protocole de 65536 pixels"
+        "geometry": "La géométrie de la scène dépasse le maximum du protocole de {max} pixels"
       },
       "submit": "Enregistrer",
       "cancel": "Annuler"

--- a/webapp/apps/frontend/i18n/locales/fr.json
+++ b/webapp/apps/frontend/i18n/locales/fr.json
@@ -86,6 +86,7 @@
       },
       "actions": {
         "create": "Nouvelle scène",
+        "edit": "Modifier",
         "delete": "Supprimer"
       }
     }
@@ -150,6 +151,24 @@
         "geometry": "La géométrie de la scène dépasse le maximum du protocole de 65536 pixels"
       },
       "submit": "Créer",
+      "cancel": "Annuler"
+    },
+    "editScene": {
+      "title": "Modifier la scène",
+      "failure": {
+        "title": "Échec de la modification",
+        "unknownDescription": "Une erreur inconnue s'est produite lors de la tentative de modification de la scène."
+      },
+      "fields": {
+        "name": "Nom",
+        "width": "Largeur (px)",
+        "height": "Hauteur (px)",
+        "targetFps": "Cadence cible"
+      },
+      "validation": {
+        "geometry": "La géométrie de la scène dépasse le maximum du protocole de 65536 pixels"
+      },
+      "submit": "Enregistrer",
       "cancel": "Annuler"
     }
   },

--- a/webapp/apps/frontend/i18n/locales/fr.json
+++ b/webapp/apps/frontend/i18n/locales/fr.json
@@ -75,6 +75,19 @@
         "delete": "Supprimer",
         "rotateToken": "Régénérer le token"
       }
+    },
+    "scenes": {
+      "title": "Mes scènes",
+      "table": {
+        "name": "Nom",
+        "size": "Taille (l x h)",
+        "targetFps": "Cadence cible",
+        "version": "Version"
+      },
+      "actions": {
+        "create": "Nouvelle scène",
+        "delete": "Supprimer"
+      }
     }
   },
   "validation": {
@@ -87,7 +100,8 @@
     "logout": "Se déconnecter",
     "platform": "Plateforme",
     "matrices": "Matrices",
-    "renderers": "Renderers"
+    "renderers": "Renderers",
+    "scenes": "Scènes"
   },
   "app": {
     "name": "Matrix Led SSR",
@@ -119,6 +133,24 @@
       "submit": "Créer",
       "cancel": "Annuler",
       "done": "Terminé"
+    },
+    "createScene": {
+      "title": "Créer une scène",
+      "failure": {
+        "title": "Échec de la création",
+        "unknownDescription": "Une erreur inconnue s'est produite lors de la tentative de création d'une scène."
+      },
+      "fields": {
+        "name": "Nom",
+        "width": "Largeur (px)",
+        "height": "Hauteur (px)",
+        "targetFps": "Cadence cible"
+      },
+      "validation": {
+        "geometry": "La géométrie de la scène dépasse le maximum du protocole de 65536 pixels"
+      },
+      "submit": "Créer",
+      "cancel": "Annuler"
     }
   },
   "dialogs": {
@@ -151,6 +183,16 @@
       "failure": {
         "title": "Échec de la régénération",
         "unknownDescription": "Une erreur inconnue s'est produite lors de la tentative de régénération du token."
+      }
+    },
+    "deleteScene": {
+      "title": "Supprimer la scène",
+      "description": "Êtes-vous sûr de vouloir supprimer la scène {0} ? Cette action est irréversible.",
+      "cancel": "Annuler",
+      "confirm": "Supprimer",
+      "failure": {
+        "title": "Échec de la suppression",
+        "unknownDescription": "Une erreur inconnue s'est produite lors de la tentative de suppression de la scène."
       }
     }
   },


### PR DESCRIPTION
Second vertical slice of #7: the `Scene` entity, end to end.

`Scene` lands before `Device` (#17) because `devices.sceneId` will reference `scenes`, so the table has to
exist for that migration to be complete in one pass. It's a standalone, owned entity — no FK to Device or
Renderer.

## Backend

- `scenes` migration: `userId`, `name`, `width`/`height`, `targetFps` (default 30), `config` (jsonb), `version`.
  DB-level `CHECK` constraints mirror the app-level bounds (`width * height <= 65536`, `1 <= targetFps <= 60`),
  the same belt-and-suspenders pattern as the renderer default-index check, plus an index on `user_id`, which
  every listing filters by and which a foreign key does not create on its own in PostgreSQL.
- `app/validators/scene.ts`: the versioned envelope (`{ version: 1, nodes: [] }`) replaces the
  `vine.record(vine.any())` blob `Matrix.config` still uses. Each node is only required to be a tagged object
  (`{ type: string, ...anything }`) — the primitive catalogue doesn't exist yet, so the envelope validates
  structure without hardcoding primitives, and adding one later never touches it.
- The pixel bound lives in `app/constants/scene.ts` as `PROTOCOL_MAXIMUM_PIXELS` and is exported to the
  frontend through the package's `./constants/scene` subpath, so the form and the API can't drift apart. The
  migration keeps the literal on purpose: a migration is a snapshot of the schema at its date.
- `width * height <= PROTOCOL_MAXIMUM_PIXELS` is enforced by a shared VineJS rule, used on create and re-run in
  `SceneService.patchScene` against the *merged* geometry — a PATCH touching only `width` can't see the
  unpatched `height` still in the row, so the request-level validator alone can't catch a merge that overflows.
  The rule is compiled once rather than re-compiled per call, since `vine.validate({ schema })` rebuilds the
  validation function on every invocation.
- `scenes.version` is a row-revision counter (distinct from the envelope's own `config.version`), bumped on
  every change — a rename included. Lucid's dirty tracking decides, so it deep-compares against the loaded row:
  a client resubmitting an untouched form, which the edit sheet does on every save, bumps nothing. The
  increment is done in SQL, not read-modify-written in JS, so two concurrent patches can't lose one.
- Service, owner-based policy (plain, like `matrix_policy.ts` — no platform-sharing branch like Renderer's),
  transformer, thin controller, `scenes.*` routes.
- `database/schema_rules.ts` narrows `scenes.config`'s generated type from `any` to the validator's inferred
  `SceneConfig`, the same treatment `renderers.status` already got.

## Frontend

- `/scenes`: list, create, edit and delete. Geometry fields sit side by side; target FPS uses a slider over the
  full `1..60` range the validator and the `CHECK` constraint declare — a narrower slider silently rewrote the
  cadence of any scene stored below its minimum.
- Both forms import `PROTOCOL_MAXIMUM_PIXELS` from the backend package and interpolate it into the geometry
  message, so the number appears once in the codebase.
- Config editing (a node editor) is explicitly out of scope — no primitive catalogue exists yet, so there's
  nothing to edit. Create/edit only take name, geometry and cadence; `config` defaults server-side to
  `{ version: 1, nodes: [] }`.
- Edit was originally going to land with device-assignment work in #44, whose own intro already said basic
  scene edit ships here — dropped the duplicate from #44 rather than leave the two issues disagreeing.

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test` (36 passing), `pnpm build` and `pnpm format:check` all green. Walked
in the browser: create, edit, delete, and the 403/401 paths from the test suite spot-checked against a second
account. The functional suite covers the version rules directly: any change bumps it, an unchanged resubmission
— `config` envelope included — does not.

Closes #18
