### PR TITLE
fix(webapp.frontend): derive the breadcrumb from the current route

### DIFF
--- a/webapp/apps/frontend/app/breadcrumb.d.ts
+++ b/webapp/apps/frontend/app/breadcrumb.d.ts
@@ -1,0 +1,18 @@
+export interface BreadcrumbEntry {
+  /** i18n key of the label to display. */
+  label: string
+  /** Path to link to. The last entry of a trail is never linked. */
+  to?: string
+}
+
+declare module '#app' {
+  interface PageMeta {
+    breadcrumb?: BreadcrumbEntry[]
+  }
+}
+
+declare module 'vue-router' {
+  interface RouteMeta {
+    breadcrumb?: BreadcrumbEntry[]
+  }
+}

--- a/webapp/apps/frontend/app/components/AppBreadcrumb.vue
+++ b/webapp/apps/frontend/app/components/AppBreadcrumb.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+const route = useRoute()
+const { t } = useI18n()
+
+const entries = computed(() => route.meta.breadcrumb ?? [])
+</script>
+
+<template>
+  <UiBreadcrumb v-if="entries.length">
+    <UiBreadcrumbList>
+      <template v-for="(entry, index) in entries" :key="entry.label">
+        <UiBreadcrumbItem :class="index < entries.length - 1 ? 'hidden md:block' : undefined">
+          <UiBreadcrumbPage v-if="index === entries.length - 1">
+            {{ t(entry.label) }}
+          </UiBreadcrumbPage>
+          <UiBreadcrumbLink v-else-if="entry.to" as-child>
+            <NuxtLink :to="entry.to">{{ t(entry.label) }}</NuxtLink>
+          </UiBreadcrumbLink>
+          <span v-else>{{ t(entry.label) }}</span>
+        </UiBreadcrumbItem>
+        <UiBreadcrumbSeparator v-if="index < entries.length - 1" class="hidden md:block" />
+      </template>
+    </UiBreadcrumbList>
+  </UiBreadcrumb>
+</template>

--- a/webapp/apps/frontend/app/layouts/default.vue
+++ b/webapp/apps/frontend/app/layouts/default.vue
@@ -10,17 +10,7 @@
         <div class="flex items-center gap-2 px-4">
           <UiSidebarTrigger class="-ml-1" />
           <UiSeparator orientation="vertical" class="mr-2 data-[orientation=vertical]:h-4" />
-          <UiBreadcrumb>
-            <UiBreadcrumbList>
-              <UiBreadcrumbItem class="hidden md:block">
-                <UiBreadcrumbLink href="#"> Building Your Application </UiBreadcrumbLink>
-              </UiBreadcrumbItem>
-              <UiBreadcrumbSeparator class="hidden md:block" />
-              <UiBreadcrumbItem>
-                <UiBreadcrumbPage>Data Fetching</UiBreadcrumbPage>
-              </UiBreadcrumbItem>
-            </UiBreadcrumbList>
-          </UiBreadcrumb>
+          <AppBreadcrumb />
         </div>
       </header>
       <div class="flex flex-1 flex-col gap-4 p-4 pt-0">

--- a/webapp/apps/frontend/app/pages/index.vue
+++ b/webapp/apps/frontend/app/pages/index.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
 import { Trash } from 'lucide-vue-next'
+
+definePageMeta({
+  breadcrumb: [{ label: 'nav.platform' }, { label: 'nav.matrices', to: '/' }],
+})
+
 const { $api, hook } = useNuxtApp()
 
 const {

--- a/webapp/apps/frontend/app/pages/renderers.vue
+++ b/webapp/apps/frontend/app/pages/renderers.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { KeyRound, Trash } from 'lucide-vue-next'
 
+definePageMeta({
+  breadcrumb: [{ label: 'nav.platform' }, { label: 'nav.renderers', to: '/renderers' }],
+})
+
 const { t } = useI18n()
 const { $api, hook } = useNuxtApp()
 

--- a/webapp/apps/frontend/app/pages/scenes.vue
+++ b/webapp/apps/frontend/app/pages/scenes.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { Pencil, Trash } from 'lucide-vue-next'
 
+definePageMeta({
+  breadcrumb: [{ label: 'nav.platform' }, { label: 'nav.scenes', to: '/scenes' }],
+})
+
 const { t } = useI18n()
 const { $api, hook } = useNuxtApp()
 


### PR DESCRIPTION
## Problem

The header of the `default` layout still carried the shadcn starter breadcrumb, hardcoded as
`Building Your Application / Data Fetching`. It was identical on every page and unrelated to where the
user actually was.

## Change

The trail is now declared per page and rendered from the current route.

- `app/breadcrumb.d.ts` — a `BreadcrumbEntry` type (`label` is an i18n key, `to` is optional) plus the
  `PageMeta` / `RouteMeta` augmentations, in the same style as the existing `app/hooks.d.ts`.
- `app/components/AppBreadcrumb.vue` — reads `route.meta.breadcrumb`, translates the labels, renders the
  last segment as a `BreadcrumbPage` (not a link, `aria-current="page"`) and the earlier ones as links when
  they carry a `to`. Separators and the `hidden md:block` treatment of intermediate segments are kept.
- `app/layouts/default.vue` — the hardcoded markup is replaced by `<AppBreadcrumb />`.
- The three pages using that layout declare their trail through `definePageMeta`:
  - `/` → Platform / Matrices
  - `/scenes` → Platform / Scenes
  - `/renderers` → Platform / Renderers

Labels reuse the `nav.*` keys already present in `en.json` and `fr.json`, so no new translation is needed,
and "Platform" matches the sidebar group label. `login` and `register` use the `empty` layout and are
unaffected; the `v-if` on the component keeps a page that declares no trail from rendering an empty one.

Detail pages for devices and scenes will only need a third segment in their `definePageMeta`.

## Checks

`pnpm build` and `pnpm format:check` pass. The frontend still has no type checker installed, so it is not
typechecked here either.