### PR TITLE
Type-check the Nuxt frontend in CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,12 @@ pnpm format        # rewrites
 pnpm format:check  # reports, exits 1 — this is what CI runs
 ```
 
-Note that `lint`, `typecheck` and `test` only exercise the **backend** — the frontend package defines no such
-scripts. A green `pnpm typecheck` says nothing about the Nuxt app. `format:check` is the one check that covers
-both packages. `.github/workflows/ci.yml` runs these four commands on every pull request, so a green CI still
-says nothing about whether the frontend compiles or works.
+`typecheck` and `format:check` cover **both** packages; `lint` and `test` still only exercise the **backend**.
+The frontend's `typecheck` runs `nuxt typecheck` (vue-tsc), which checks `.vue` templates as well as scripts —
+that is what makes the end-to-end type safety below an actual check rather than a promise. It compiles the
+backend sources the Tuyau registry pulls in, so it is a second, stricter reading of part of the backend too.
+`.github/workflows/ci.yml` runs these four commands on every pull request. A green CI does not say the Nuxt app
+*works* — there is no frontend test suite — but it does say it compiles.
 
 ### Backend
 
@@ -112,11 +114,16 @@ const { $api } = useNuxtApp()
 const [data, error] = await $api.request('matrices.index', {}).safe()
 ```
 
-Route names come from the group/route `.as()` chain in `start/routes.ts`. Renaming a route silently breaks the
-frontend at the type level, so run a backend build after touching route names.
+Route names come from the group/route `.as()` chain in `start/routes.ts`. Renaming a route breaks the frontend
+at the type level; `pnpm typecheck` catches it, since Turbo rebuilds the backend registry first.
 
 Turbo's `dependsOn: ["^build"]` exists precisely because the frontend cannot typecheck before the backend has
 generated its registry.
+
+The registry is exported as TypeScript **source**, and its types reach into the controllers, validators and
+Lucid models — so a frontend typecheck compiles those backend files under the Nuxt program's own options. That
+is why `nuxt.config.ts` sets `experimentalDecorators`, without which Lucid's decorators do not parse. See
+[ADR-0023](docs/adr/0023-typecheck-du-frontend-par-vue-tsc.md).
 
 ### API response shape
 

--- a/docs/adr/0023-typecheck-du-frontend-par-vue-tsc.md
+++ b/docs/adr/0023-typecheck-du-frontend-par-vue-tsc.md
@@ -1,0 +1,73 @@
+# ADR-0023 — Le frontend est type-vérifié par `vue-tsc`, sur le même programme que les sources du backend
+
+**Statut** : Accepté — 2026-09-02
+
+## Contexte
+
+La promesse structurante du projet est la **sûreté de type de bout en bout** : le frontend importe le backend
+comme dépendance d'espace de travail et construit son client API depuis le registre Tuyau généré, si bien qu'un
+appel se fait par **nom de route** et non par URL. Renommer une route casse le frontend au niveau des types.
+
+Or **rien ne vérifiait que cette promesse tenait**. Le paquet frontend ne déclarait aucun script `typecheck`,
+donc `pnpm typecheck` — que la CI lance — n'exerçait que le backend. `nuxt build` compile sans vérifier les
+types : Vite transpile, il ne type-vérifie pas. Aucune des quatre commandes de la CI ne lisait une seule
+annotation de type du Nuxt. Un renommage de route, une prop absente, un composant inexistant dans un template
+passaient tous en vert.
+
+## Décision
+
+**Le paquet frontend déclare `typecheck: nuxt typecheck`, adossé à `vue-tsc`**, et la tâche Turbo `typecheck`
+existante — déjà porteuse de `dependsOn: ["^build"]` — le branche dans la CI sans y toucher.
+
+Deux choix le structurent.
+
+**`vue-tsc` plutôt que Golar.** `nuxt typecheck` accepte les deux. `vue-tsc` est le vérificateur de référence de
+l'écosystème Vue, en 3.3.11, aligné sur `@vue/language-core`, et il honore les `vueCompilerOptions` déjà posées
+dans `nuxt.config.ts` (`checkUnknownComponents`). Golar est en 0.1.x et exigerait un fichier de configuration
+supplémentaire ; sa maturité ne justifie pas d'en dépendre pour un contrôle que la CI doit pouvoir croire.
+
+**Le programme du frontend active `experimentalDecorators`.** `@matrixled-ssr/backend/registry` est exporté en
+**source TypeScript**, et `registry/schema.d.ts` référence les contrôleurs et les validateurs par
+`import('#controllers/…')`. Ces fichiers, et par transitivité les modèles Lucid et `database/schema.ts`, sont
+donc compilés **dans le programme du frontend**, avec les options de Nuxt et non celles du backend. Sans
+`experimentalDecorators`, `@column` et `@belongsTo` produisent 41 `TS1206: Decorators are not valid here`
+et 4 `TS1241` venus du backend, qui noient tout le reste. L'option était d'ailleurs **déjà** écrite dans
+`apps/frontend/tsconfig.json`, où elle est inerte : ce fichier est un tsconfig « solution » (`files: []`) dont
+les `compilerOptions` ne s'appliquent à aucun programme. La décision ne fait que rendre effective une intention
+déjà exprimée. Elle est portée par `nuxt.config.ts`, `.nuxt/` étant régénéré et non versionné.
+
+## Alternatives écartées
+
+**Exclure les sources du backend du périmètre.** La plus courte, et la pire : le seul chemin par lequel le
+frontend voit les types du backend est justement celui qu'on aurait coupé. Exclure `../backend/**` aurait rendu
+le contrôle vert en supprimant ce qu'il devait vérifier.
+
+**Relâcher les options qui font échouer les fichiers du backend** (`noImplicitOverride`,
+`noUncheckedIndexedAccess`). Écarté parce que ces options sont celles de Nuxt et protègent le **code du
+frontend** : les désactiver pour faire taire neuf erreurs venues du backend aurait affaibli la vérification là
+où elle est neuve. Les neuf erreurs ont été corrigées à la source — huit `override` manquants, un accès non
+gardé — sans `@ts-ignore` ni `any`.
+
+**Faire consommer au frontend des déclarations construites plutôt que les sources du backend.** Ce serait la
+réponse propre au couplage décrit ci-dessus, et elle supprimerait la nécessité d'`experimentalDecorators`. Mais
+elle demande de changer la carte `exports` du backend et l'émission de Tuyau, c'est-à-dire de rouvrir la chaîne
+de génération pour un bénéfice d'hygiène. Reportée : le coût actuel se réduit à une option et à un commentaire.
+
+**Introduire la vérification en non-bloquant d'abord.** L'usage quand un code jamais vérifié fait surgir une
+pile d'erreurs. Sans objet ici : le code du frontend n'en produisait **aucune**, et les neuf du backend étaient
+réparables mécaniquement. Un contrôle non bloquant qui pourrait être bloquant est un contrôle qu'on apprend à
+ignorer.
+
+## Conséquences
+
+- **Le contrat de routes est vérifié.** Un `.as()` renommé côté backend fait désormais échouer `pnpm typecheck`
+  au lieu de casser silencieusement le frontend. Turbo reconstruit le registre avant, par `^build`.
+- **Une partie du backend est lue deux fois, sous deux jeux d'options.** Ce qui traverse le registre est compilé
+  aussi par le programme du frontend, plus strict. Une erreur de types du backend peut donc apparaître dans la
+  tâche `typecheck` du **frontend** — c'est le prix du couplage, et un signal, pas un faux positif.
+- **`vue-tsc` et `typescript` deviennent des dépendances de développement du frontend**, et le `typecheck`
+  complet passe de ~1 s à ~6 s.
+- **Ce que le contrôle n'attrape pas.** Il ne vérifie que ce qui est typé. Restent hors de portée : les clés de
+  `useAsyncData` et les types d'événements du dashboard, qui sont des **chaînes** rapprochées à l'exécution ;
+  les clés i18n ; le contenu de `Matrix.config`, typé `any` ; et tout ce qui relève du comportement — il n'y a
+  pas de suite de tests frontend, et un composant qui compile peut ne rien afficher.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,3 +41,4 @@ rouvre en refaisant toute l'analyse.
 | [0020](0020-simulateur-device-declare.md) | Le simulateur est un device déclaré, pas un device emprunté | Accepté |
 | [0021](0021-credential-du-simulateur-par-rotation.md) | Le simulateur obtient son credential par rotation à l'ouverture | Accepté |
 | [0022](0022-notifications-dashboard-par-sse.md) | Notifications du dashboard en SSE, émises par un bus d'événements de domaine | Accepté |
+| [0023](0023-typecheck-du-frontend-par-vue-tsc.md) | Type-vérification du frontend par `vue-tsc`, sur le même programme que les sources du backend | Accepté |

--- a/webapp/apps/backend/app/exceptions/handler.ts
+++ b/webapp/apps/backend/app/exceptions/handler.ts
@@ -6,13 +6,13 @@ export default class HttpExceptionHandler extends ExceptionHandler {
    * In debug mode, the exception handler will display verbose errors
    * with pretty printed stack traces.
    */
-  protected debug = !app.inProduction
+  protected override debug = !app.inProduction
 
   /**
    * The method is used for handling errors and returning
    * response to the client
    */
-  async handle(error: unknown, ctx: HttpContext) {
+  override async handle(error: unknown, ctx: HttpContext) {
     return super.handle(error, ctx)
   }
 
@@ -22,7 +22,7 @@ export default class HttpExceptionHandler extends ExceptionHandler {
    *
    * @note You should not attempt to send a response from this method.
    */
-  async report(error: unknown, ctx: HttpContext) {
+  override async report(error: unknown, ctx: HttpContext) {
     return super.report(error, ctx)
   }
 }

--- a/webapp/apps/backend/app/models/matrix.ts
+++ b/webapp/apps/backend/app/models/matrix.ts
@@ -4,7 +4,7 @@ import User from './user.ts'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 
 export default class Matrix extends MatrixSchema {
-  static selfAssignPrimaryKey = true
+  static override selfAssignPrimaryKey = true
 
   @belongsTo(() => User)
   declare user: BelongsTo<typeof User>

--- a/webapp/apps/backend/app/models/renderer.ts
+++ b/webapp/apps/backend/app/models/renderer.ts
@@ -4,7 +4,7 @@ import User from './user.ts'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 
 export default class Renderer extends RendererSchema {
-  static selfAssignPrimaryKey = true
+  static override selfAssignPrimaryKey = true
 
   /**
    * A null owner is the platform renderer, shared by every user.

--- a/webapp/apps/backend/app/models/scene.ts
+++ b/webapp/apps/backend/app/models/scene.ts
@@ -4,7 +4,7 @@ import User from './user.ts'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 
 export default class Scene extends SceneSchema {
-  static selfAssignPrimaryKey = true
+  static override selfAssignPrimaryKey = true
 
   @belongsTo(() => User)
   declare user: BelongsTo<typeof User>

--- a/webapp/apps/backend/app/models/user.ts
+++ b/webapp/apps/backend/app/models/user.ts
@@ -8,14 +8,14 @@ import { randomUUID } from 'node:crypto'
 import Matrix from './matrix.ts'
 
 export default class User extends compose(UserSchema, withAuthFinder(hash)) {
-  static selfAssignPrimaryKey = true
+  static override selfAssignPrimaryKey = true
 
   get initials() {
     const [first, last] = this.fullName ? this.fullName.split(' ') : this.email.split('@')
     if (first && last) {
       return `${first.charAt(0)}${last.charAt(0)}`.toUpperCase()
     }
-    return `${first.slice(0, 2)}`.toUpperCase()
+    return `${first?.slice(0, 2) ?? ''}`.toUpperCase()
   }
 
   @hasMany(() => Matrix)

--- a/webapp/apps/backend/app/transformers/renderer_with_token_transformer.ts
+++ b/webapp/apps/backend/app/transformers/renderer_with_token_transformer.ts
@@ -13,7 +13,7 @@ export default class RendererWithTokenTransformer extends RendererTransformer {
     super(resource)
   }
 
-  toObject() {
+  override toObject() {
     return {
       ...super.toObject(),
       token: this.token,

--- a/webapp/apps/frontend/nuxt.config.ts
+++ b/webapp/apps/frontend/nuxt.config.ts
@@ -31,6 +31,17 @@ export default defineNuxtConfig({
   },
   typescript: {
     tsConfig: {
+      compilerOptions: {
+        /**
+         * `@matrixled-ssr/backend/registry` is exported as TypeScript source, and
+         * its types reach into the controllers, validators and Lucid models. Those
+         * files are therefore compiled as part of *this* program, and Lucid's
+         * `@column`/`@belongsTo` decorators only parse under the legacy semantics
+         * the backend's own tsconfig enables. Without this, a frontend typecheck
+         * drowns in `TS1206: Decorators are not valid here` coming from the backend.
+         */
+        experimentalDecorators: true,
+      },
       vueCompilerOptions: {
         checkUnknownComponents: true,
       },

--- a/webapp/apps/frontend/package.json
+++ b/webapp/apps/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "typecheck": "nuxt typecheck"
   },
   "dependencies": {
     "@adonisjs/transmit-client": "^1.1.0",
@@ -36,6 +37,8 @@
     "@nuxtjs/color-mode": "^4.0.1",
     "@nuxtjs/tailwindcss": "7.0.0-beta.1",
     "tailwindcss": "^4.3.3",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "typescript": "~6.0.3",
+    "vue-tsc": "^3.3.11"
   }
 }

--- a/webapp/pnpm-lock.yaml
+++ b/webapp/pnpm-lock.yaml
@@ -155,7 +155,7 @@ importers:
         version: 1.0.0(vue@3.5.42(typescript@6.0.3))
       nuxt:
         specifier: ^4.5.2
-        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.147.0)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.42)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.6)(rollup@4.63.1))(rollup@4.63.1)(srvx@0.11.22)(terser@5.51.2)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.147.0)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.42)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.6)(rollup@4.63.1))(rollup@4.63.1)(srvx@0.11.22)(terser@5.51.2)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@6.0.3))(yaml@2.9.0)
       reka-ui:
         specifier: ^2.10.4
         version: 2.10.4(vue@3.5.42(typescript@6.0.3))
@@ -190,6 +190,12 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3
+      vue-tsc:
+        specifier: ^3.3.11
+        version: 3.3.11(typescript@6.0.3)
 
 packages:
 
@@ -2708,6 +2714,15 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
   '@vue-macros/common@3.1.4':
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
     engines: {node: '>=20.19.0'}
@@ -2771,6 +2786,9 @@ packages:
   '@vue/devtools-shared@8.2.1':
     resolution: {integrity: sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==}
 
+  '@vue/language-core@3.3.11':
+    resolution: {integrity: sha512-QJmpliwAVpC/OxubIByPAhNzsQPRc8/gxlN2qnVzVfIMjMDz/9RnXRFoetjz5yEgXVXyp4LqhXq3V53PjmNzFw==}
+
   '@vue/reactivity@3.5.42':
     resolution: {integrity: sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==}
 
@@ -2831,6 +2849,9 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   angular-html-parser@10.11.0:
     resolution: {integrity: sha512-3vERzJ65UFDr3C7uozLJwsNcQS3FS784dSh583oDgDTTZMgXe3/pdyXgKndxiP5R2lvYRfW6gSl145Hnyf2OFA==}
@@ -6154,6 +6175,9 @@ packages:
       yaml:
         optional: true
 
+  vscode-uri@3.2.0:
+    resolution: {integrity: sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==}
+
   vue-bundle-renderer@2.3.2:
     resolution: {integrity: sha512-BtazFw0lm3N/ZE4+tre2g8G+c5wolfizu+e5jxZAcao0gcy5KJei9Yopl1svDato2poeFldVLfmLMk57Sg8rLg==}
 
@@ -6197,6 +6221,12 @@ packages:
         optional: true
       vite:
         optional: true
+
+  vue-tsc@3.3.11:
+    resolution: {integrity: sha512-gOb0B9rtU2+f1dszwPqSH5kAieIF9ReeLhD3kSRNHv5WZZUQz/JdVXW0RTdqhNTMlQkqKzrTTviqKr/4FYZraQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
 
   vue@3.5.42:
     resolution: {integrity: sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==}
@@ -7619,7 +7649,7 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server@4.5.2(a0f63b990b920b5f65a4312efe40aec5)':
+  '@nuxt/nitro-server@4.5.2(dde07a1b9e4b1b927a16633fc4355705)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)))
@@ -7638,7 +7668,7 @@ snapshots:
       mocked-exports: 0.1.1
       nitropack: 2.13.4(oxc-parser@0.141.0)(rolldown@1.2.6)(srvx@0.11.22)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.147.0)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.42)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.6)(rollup@4.63.1))(rollup@4.63.1)(srvx@0.11.22)(terser@5.51.2)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.147.0)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.42)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.6)(rollup@4.63.1))(rollup@4.63.1)(srvx@0.11.22)(terser@5.51.2)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.9
       ohash: 2.0.12
       pathe: 2.0.3
@@ -7723,7 +7753,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.2(0d114a00a7d8455d3bc18d236d4886c4)':
+  '@nuxt/vite-builder@4.5.2(edf57d4f6591cd3e18c4b5e6d867b292)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
@@ -7741,7 +7771,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.147.0)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.42)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.6)(rollup@4.63.1))(rollup@4.63.1)(srvx@0.11.22)(terser@5.51.2)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.147.0)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.42)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.6)(rollup@4.63.1))(rollup@4.63.1)(srvx@0.11.22)(terser@5.51.2)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -7753,7 +7783,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
-      vite-plugin-checker: 0.14.5(eslint@10.9.1(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))
+      vite-plugin-checker: 0.14.5(eslint@10.9.1(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@6.0.3))
       vue: 3.5.42(typescript@6.0.3)
       vue-bundle-renderer: 2.3.2
     optionalDependencies:
@@ -8851,6 +8881,18 @@ snapshots:
       vite: 8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
       vue: 3.5.42(typescript@6.0.3)
 
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.2.0
+
   '@vue-macros/common@3.1.4(vue@3.5.42(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.42
@@ -8959,6 +9001,16 @@ snapshots:
 
   '@vue/devtools-shared@8.2.1': {}
 
+  '@vue/language-core@3.3.11':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.42
+      '@vue/shared': 3.5.42
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.7
+
   '@vue/reactivity@3.5.42':
     dependencies:
       '@vue/shared': 3.5.42
@@ -9022,6 +9074,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  alien-signals@3.2.1: {}
 
   angular-html-parser@10.11.0: {}
 
@@ -10846,16 +10900,16 @@ snapshots:
 
   nuxt-define@1.0.0: {}
 
-  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.147.0)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.42)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.6)(rollup@4.63.1))(rollup@4.63.1)(srvx@0.11.22)(terser@5.51.2)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.147.0)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.42)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.6)(rollup@4.63.1))(rollup@4.63.1)(srvx@0.11.22)(terser@5.51.2)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.10(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
       '@nuxt/devtools': 3.4.2(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.2.3)(oxc-parser@0.141.0)(rolldown@1.2.6)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)))(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.2(a0f63b990b920b5f65a4312efe40aec5)
+      '@nuxt/nitro-server': 4.5.2(dde07a1b9e4b1b927a16633fc4355705)
       '@nuxt/schema': 4.5.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.2(0d114a00a7d8455d3bc18d236d4886c4)
+      '@nuxt/vite-builder': 4.5.2(edf57d4f6591cd3e18c4b5e6d867b292)
       '@unhead/vue': 3.4.0(@oxc-project/types@0.147.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       '@vue/shared': 3.5.42
       chokidar: 5.0.0
@@ -12380,7 +12434,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.14.5(eslint@10.9.1(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)):
+  vite-plugin-checker@0.14.5(eslint@10.9.1(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@6.0.3)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -12394,6 +12448,7 @@ snapshots:
       eslint: 10.9.1(jiti@2.7.0)
       optionator: 0.9.4
       typescript: 6.0.3
+      vue-tsc: 3.3.11(typescript@6.0.3)
 
   vite-plugin-inspect@11.4.1(@nuxt/kit@4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.6)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))))(vite@8.2.2(@types/node@25.6.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)):
     dependencies:
@@ -12434,6 +12489,8 @@ snapshots:
       jiti: 2.7.0
       terser: 5.51.2
       yaml: 2.9.0
+
+  vscode-uri@3.2.0: {}
 
   vue-bundle-renderer@2.3.2:
     dependencies:
@@ -12486,6 +12543,12 @@ snapshots:
       - rollup
       - unloader
       - webpack
+
+  vue-tsc@3.3.11(typescript@6.0.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.11
+      typescript: 6.0.3
 
   vue@3.5.42(typescript@6.0.3):
     dependencies:


### PR DESCRIPTION
## Le trou

Le paquet frontend ne déclarait **aucun** script `typecheck`. `pnpm typecheck` — que la CI lance — n'exerçait
donc que le backend, et `nuxt build` compile sans vérifier les types. Aucune des quatre commandes de la CI ne
lisait une annotation de type du Nuxt : un `.as()` renommé côté backend cassait le frontend au niveau des types
en laissant la CI verte. C'est précisément la promesse de sûreté bout en bout du projet qui n'était vérifiée par
rien.

## Ce que fait cette PR

- `apps/frontend` déclare `typecheck: nuxt typecheck`, adossé à **`vue-tsc` 3.3.11**. La tâche Turbo `typecheck`
  existante porte déjà `dependsOn: ["^build"]`, donc le registre Tuyau est régénéré avant : **aucune
  modification de `turbo.json` ni de `ci.yml`** n'a été nécessaire.
- `nuxt.config.ts` active `experimentalDecorators` pour le programme du frontend. Le registre est exporté en
  **source TypeScript** et ses types atteignent contrôleurs, validateurs et modèles Lucid : ces fichiers sont
  compilés dans le programme du frontend, où les décorateurs Lucid ne parsent pas autrement (41 `TS1206`).
  L'option était déjà écrite dans `apps/frontend/tsconfig.json`, où elle est inerte (tsconfig « solution »).
- Correction des **9 erreurs** restantes, toutes dans des fichiers du backend : 8 `override` manquants
  (`noImplicitOverride`) et un accès non gardé (`noUncheckedIndexedAccess`).

**Le code du frontend lui-même ne produisait aucune erreur.** 54 erreurs avant, toutes venues du backend lu
sous les options plus strictes de Nuxt.

Rien n'a été affaibli pour faire passer le contrôle : ni `@ts-ignore`, ni `any`, ni règle désactivée, ni fichier
exclu du périmètre.

## Vérifié

Une sonde temporaire confirme que le contrôle attrape bien ce qu'il doit :

```
app/pages/index.vue(9,26): error TS2345: Argument of type '"matrices.indexxx"' is not assignable to parameter of type '"matrices.index" | ...'
app/pages/index.vue(23,4): error TS2339: Property 'UiDoesNotExist' does not exist on type '{}'
```

Nom de route inexistant **et** composant inconnu dans un template (`checkUnknownComponents` était déjà posé,
mais rien ne l'exécutait).

## Ce que ça n'attrape pas

Seulement ce qui est typé. Restent hors de portée : les clés de `useAsyncData` et les types d'événements du
dashboard, qui sont des **chaînes** rapprochées à l'exécution ; les clés i18n ; `Matrix.config`, typé `any` ; et
tout le comportement — il n'existe pas de suite de tests frontend, et un composant qui compile peut ne rien
afficher.

## Documentation

`CLAUDE.md` décrivait ce trou ; il est mis à jour. [ADR-0023](docs/adr/0023-typecheck-du-frontend-par-vue-tsc.md)
consigne le choix de `vue-tsc` (contre Golar, en 0.1.x) et le couplage qui impose `experimentalDecorators`, avec
l'alternative propre — faire consommer au frontend des déclarations construites — explicitement reportée.