### PR TITLE
Renderer endpoints as a list

### DIFF
--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -28,7 +28,7 @@ Un moteur de rendu déclaré auprès de la plateforme.
 | `isDefault` | boolean | Renderer assigné par défaut aux nouveaux devices |
 | `version` | string \| null | Version annoncée à la connexion. `null` tant qu'il ne s'est pas connecté |
 | `capabilities` | jsonb \| null | Primitives que ce renderer sait rendre. `null` tant qu'il ne s'est pas connecté |
-| `endpoints` | jsonb \| null | Adresses annoncées, transmises telles quelles aux devices au bootstrap. Liste : `wss://`, `ws://`, ou les deux ([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)) |
+| `endpoints` | jsonb \| null | Adresses annoncées, transmises telles quelles aux devices au bootstrap. Liste de 1 à 4 URL `ws://` ou `wss://` ([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)). `null` tant qu'il ne s'est pas connecté |
 | `status` | enum | `online` \| `offline` |
 | `lastSeenAt` | timestamptz \| null | Dernière activité sur le canal de contrôle |
 | `createdAt` / `updatedAt` | timestamptz | |
@@ -37,7 +37,9 @@ Un moteur de rendu déclaré auprès de la plateforme.
 
 - Exactement un renderer porte `isDefault = true` et `ownerId = null`.
 - `version`, `capabilities` et `endpoints` sont **déclarés par le renderer** à sa connexion. Ce sont des données
-  non fiables : Adonis les valide et les borne avant de les persister.
+  non fiables : Adonis les valide et les borne avant de les persister. Pour `endpoints`, la borne est de 1 à 4
+  entrées d'au plus 255 caractères, chacune une URL en `ws://` ou `wss://` — une liste vide n'est pas une
+  déclaration, c'est `null`.
 - `status` et `lastSeenAt` sont dérivés de l'état de la connexion de contrôle, jamais renseignés par une requête.
 
 ## Device

--- a/docs/PROTOCOL-CONTROL.md
+++ b/docs/PROTOCOL-CONTROL.md
@@ -82,6 +82,10 @@ transmet telle quelle au bootstrap et **ne choisit pas** à la place du client
 ([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)). Il ne peut d'ailleurs rien vérifier : un renderer
 auto-hébergé lui est injoignable.
 
+Ce qu'il fait, c'est **borner** : de 1 à 4 entrées, chacune une URL en `ws://` ou `wss://` d'au plus 255
+caractères. Un `hello` qui dépasse est rejeté — la borne protège la taille de la ligne, elle ne cherche pas à
+deviner quelle adresse était la bonne.
+
 `state_version` est le pivot de la resynchronisation.
 
 ### `device.status`

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -74,7 +74,8 @@ capacités affichera un résultat faux au lieu de refuser une scène.
 | `max_pixels_per_device` | Plafond de géométrie. Ne peut excéder 65 536 ([PROTOCOL-DEVICE.md](PROTOCOL-DEVICE.md)) |
 
 Le renderer déclare en outre ses **`endpoints`** : les adresses auxquelles ses devices peuvent le joindre,
-`wss://`, `ws://`, ou les deux ([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)). Sur un réseau
+`wss://`, `ws://`, ou les deux, de 1 à 4 entrées d'au plus 255 caractères
+([ADR-0016](adr/0016-transports-declares-par-le-renderer.md)). Sur un réseau
 local, `ws://` en clair est un choix assumé : sans certificat reconnu, un `wss://` auto-signé non épinglé
 n'apporte que du chiffrement, pas d'authentification. Déclarer aussi un `wss://` avec un certificat reconnu est
 ce qui rend le renderer atteignable depuis le simulateur du dashboard hébergé ([SIMULATOR.md](SIMULATOR.md)).

--- a/webapp/apps/backend/app/constants/renderer.ts
+++ b/webapp/apps/backend/app/constants/renderer.ts
@@ -1,0 +1,21 @@
+/**
+ * A renderer declares the addresses its devices can reach it on: `wss://`,
+ * `ws://`, or both (docs/adr/0016-transports-declares-par-le-renderer.md).
+ * The list is untrusted input — Adonis cannot probe a NATed renderer to check
+ * what it claims — so it is bounded before being persisted.
+ *
+ * Four entries because the `wss://` of ADR-0016 routinely comes alongside more
+ * than one LAN address: IPv4 and IPv6, two network interfaces, a name and an
+ * address, or a local address next to a public tunnel. The bound protects the
+ * size of the row; it does not model a use case, and Adonis has no way of
+ * knowing which address it would have been right to keep.
+ *
+ * Enforced twice: by the validator in app/validators/renderer.ts, which alone
+ * can reach inside the list, and by a CHECK constraint in the
+ * `1788510310378_alter_renderers_endpoints_table` migration, which carries the
+ * literal because a migration must stay a frozen snapshot of the schema at its
+ * date.
+ */
+export const RENDERER_MAXIMUM_ENDPOINTS = 4
+
+export const RENDERER_ENDPOINT_MAXIMUM_LENGTH = 255

--- a/webapp/apps/backend/app/transformers/renderer_transformer.ts
+++ b/webapp/apps/backend/app/transformers/renderer_transformer.ts
@@ -15,7 +15,7 @@ export default class RendererTransformer extends BaseTransformer<Renderer> {
       'tokenPrefix',
       'version',
       'capabilities',
-      'endpoint',
+      'endpoints',
       'status',
       'lastSeenAt',
       'createdAt',

--- a/webapp/apps/backend/app/validators/renderer.ts
+++ b/webapp/apps/backend/app/validators/renderer.ts
@@ -1,11 +1,46 @@
+import { RENDERER_ENDPOINT_MAXIMUM_LENGTH, RENDERER_MAXIMUM_ENDPOINTS } from '#constants/renderer'
 import vine from '@vinejs/vine'
+import type { Infer } from '@vinejs/vine/types'
 
 const name = () => vine.string().minLength(3).maxLength(100)
 
 /**
- * `version`, `capabilities`, `endpoint`, `status` and `lastSeenAt` are declared
- * by the renderer on the control plane or derived from its connection. None of
- * them is accepted from an HTTP request. See docs/DATA-MODEL.md.
+ * The transports a renderer announces itself on, bounded before persistence:
+ * it is untrusted input, and Adonis cannot probe a NATed renderer to check
+ * what it claims (docs/adr/0016-transports-declares-par-le-renderer.md).
+ *
+ * `require_tld` is off so that `ws://localhost:8889` — a renderer sharing the
+ * host — is a legal declaration.
+ *
+ * A factory, like every other reusable piece here: a schema instance carries
+ * the rules applied to it, so sharing one across validators shares state that
+ * is meant to be per-validator.
+ */
+const rendererEndpoints = () =>
+  vine
+    .array(
+      vine
+        .string()
+        .maxLength(RENDERER_ENDPOINT_MAXIMUM_LENGTH)
+        .url({ protocols: ['ws', 'wss'], require_protocol: true, require_tld: false })
+    )
+    .minLength(1)
+    .maxLength(RENDERER_MAXIMUM_ENDPOINTS)
+
+/**
+ * Types `renderers.endpoints` through database/schema_rules.ts, which is what
+ * keeps the column off `any`. Nothing writes it yet: the control plane that
+ * receives `renderer.hello` lands with #21.
+ */
+export const rendererEndpointsValidator = vine.create(rendererEndpoints())
+
+export type RendererEndpoints = Infer<ReturnType<typeof rendererEndpoints>>
+
+/**
+ * `version`, `capabilities`, `endpoints`, `status` and `lastSeenAt` are
+ * declared by the renderer on the control plane or derived from its
+ * connection. None of them is accepted from an HTTP request. See
+ * docs/DATA-MODEL.md.
  */
 export const showRendererValidator = vine.create({
   params: vine.object({

--- a/webapp/apps/backend/database/migrations/1788510310378_alter_renderers_endpoints_table.ts
+++ b/webapp/apps/backend/database/migrations/1788510310378_alter_renderers_endpoints_table.ts
@@ -1,0 +1,60 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'renderers'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      /**
+       * A renderer declares every transport it is reachable on, and the client
+       * picks — Adonis never chooses for it
+       * (docs/adr/0016-transports-declares-par-le-renderer.md).
+       */
+      table.jsonb('endpoints').nullable()
+    })
+
+    this.schema.raw(
+      `UPDATE ${this.tableName} SET endpoints = to_jsonb(ARRAY[endpoint]) WHERE endpoint IS NOT NULL`
+    )
+
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('endpoint')
+    })
+
+    /**
+     * The literal mirrors `RENDERER_MAXIMUM_ENDPOINTS` on purpose: a migration
+     * is a snapshot of the schema at its date and must not move when an
+     * application constant does.
+     *
+     * The check stops at the type and the length of the list. Bounding each
+     * entry — its scheme, its length — is not expressible here, since
+     * PostgreSQL forbids set-returning functions inside a CHECK constraint.
+     * That half of the bound lives in app/validators/renderer.ts.
+     */
+    this.schema.raw(
+      `ALTER TABLE ${this.tableName} ADD CONSTRAINT renderers_endpoints_bounded_check CHECK (endpoints IS NULL OR (jsonb_typeof(endpoints) = 'array' AND jsonb_array_length(endpoints) BETWEEN 1 AND 4))`
+    )
+  }
+
+  async down() {
+    this.schema.raw(
+      `ALTER TABLE ${this.tableName} DROP CONSTRAINT IF EXISTS renderers_endpoints_bounded_check`
+    )
+
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('endpoint').nullable()
+    })
+
+    /**
+     * Only the first entry survives the trip back — the singular column has
+     * nowhere to put the others.
+     */
+    this.schema.raw(
+      `UPDATE ${this.tableName} SET endpoint = endpoints->>0 WHERE endpoints IS NOT NULL`
+    )
+
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('endpoints')
+    })
+  }
+}

--- a/webapp/apps/backend/database/schema.ts
+++ b/webapp/apps/backend/database/schema.ts
@@ -6,6 +6,7 @@
 
 import { BaseModel, column } from '@adonisjs/lucid/orm'
 import { DateTime } from 'luxon'
+import type { RendererEndpoints } from '#validators/renderer'
 import type { SceneConfig } from '#validators/scene'
 
 export class MatrixSchema extends BaseModel {
@@ -42,7 +43,7 @@ export class RendererSchema extends BaseModel {
   static $columns = [
     'capabilities',
     'createdAt',
-    'endpoint',
+    'endpoints',
     'id',
     'isDefault',
     'lastSeenAt',
@@ -60,7 +61,7 @@ export class RendererSchema extends BaseModel {
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
   @column()
-  declare endpoint: string | null
+  declare endpoints: RendererEndpoints | null
   @column({ isPrimary: true })
   declare id: string
   @column()

--- a/webapp/apps/backend/database/schema_rules.ts
+++ b/webapp/apps/backend/database/schema_rules.ts
@@ -21,6 +21,15 @@ export default {
           tsType: "'online' | 'offline'",
           decorators: [{ name: '@column' }],
         },
+        /**
+         * A jsonb column the generator would otherwise type `any`; this ties
+         * it to the bounded list the validator accepts.
+         */
+        endpoints: {
+          tsType: 'RendererEndpoints',
+          decorators: [{ name: '@column' }],
+          imports: [{ source: '#validators/renderer', typeImports: ['RendererEndpoints'] }],
+        },
       },
     },
     scenes: {

--- a/webapp/apps/backend/tests/functional/renderers.spec.ts
+++ b/webapp/apps/backend/tests/functional/renderers.spec.ts
@@ -15,7 +15,7 @@ interface RendererPayload {
   isDefault: boolean
   tokenPrefix: string
   version: string | null
-  endpoint: string | null
+  endpoints: string[] | null
   status: string
   token?: string
 }
@@ -123,7 +123,7 @@ test.group('Renderers', () => {
       .json({
         name: 'Living room renderer',
         version: '9.9.9',
-        endpoint: 'wss://attacker.example',
+        endpoints: ['wss://attacker.example'],
         status: 'online',
         isDefault: true,
       })
@@ -133,7 +133,7 @@ test.group('Renderers', () => {
 
     const created = rendererFrom(response.body())
     assert.isNull(created.version)
-    assert.isNull(created.endpoint)
+    assert.isNull(created.endpoints)
     assert.equal(created.status, 'offline')
     assert.isFalse(created.isDefault)
   })

--- a/webapp/apps/backend/tests/unit/renderer_endpoints.spec.ts
+++ b/webapp/apps/backend/tests/unit/renderer_endpoints.spec.ts
@@ -1,0 +1,53 @@
+import { RENDERER_ENDPOINT_MAXIMUM_LENGTH, RENDERER_MAXIMUM_ENDPOINTS } from '#constants/renderer'
+import { rendererEndpointsValidator } from '#validators/renderer'
+import { test } from '@japa/runner'
+
+/**
+ * Nothing writes `renderers.endpoints` until the control plane lands (#21), so
+ * these tests are what makes "bounded and validated before persistence"
+ * (docs/adr/0016-transports-declares-par-le-renderer.md) an actual check
+ * rather than an intention.
+ */
+async function accepts(endpoints: unknown) {
+  await rendererEndpointsValidator.validate(endpoints)
+}
+
+test.group('Renderer endpoints', () => {
+  test('accepts the transports a renderer may announce', async () => {
+    await accepts(['wss://renderer.example.com'])
+    await accepts(['wss://renderer.lan:8889', 'ws://192.168.1.50:8889'])
+    await accepts(['ws://192.168.1.50:8889/socket'])
+  })
+
+  test('accepts an IPv6 address and a bare host', async () => {
+    await accepts(['ws://[2001:db8::50]:8889'])
+    await accepts(['ws://localhost:8889'])
+  })
+
+  test('rejects a transport a device could not open', async ({ assert }) => {
+    await assert.rejects(() => accepts(['http://192.168.1.50:8889']))
+    await assert.rejects(() => accepts(['javascript:alert(1)']))
+    await assert.rejects(() => accepts(['192.168.1.50:8889']))
+  })
+
+  test('rejects a declaration that announces nothing', async ({ assert }) => {
+    await assert.rejects(() => accepts([]))
+  })
+
+  test('rejects more entries than the bound allows', async ({ assert }) => {
+    const withinBound = Array.from(
+      { length: RENDERER_MAXIMUM_ENDPOINTS },
+      (_, index) => `ws://192.168.1.${index}:8889`
+    )
+
+    await accepts(withinBound)
+    await assert.rejects(() => accepts([...withinBound, 'ws://192.168.1.250:8889']))
+  })
+
+  test('rejects an entry longer than the bound allows', async ({ assert }) => {
+    const prefix = 'wss://renderer.example.com/'
+    const path = 'a'.repeat(RENDERER_ENDPOINT_MAXIMUM_LENGTH - prefix.length + 1)
+
+    await assert.rejects(() => accepts([`${prefix}${path}`]))
+  })
+})


### PR DESCRIPTION
Closes #54.

ADR-0016 was accepted after #16 had already shipped `renderers.endpoint` as a single string. A self-hosted
renderer sits behind NAT on a LAN address no public authority will certify, so an unpinned self-signed `wss://`
buys encryption without authentication — `ws://` on a LAN is the honest choice. But the simulator is a page of
the dashboard, and a browser served over HTTPS cannot open a `ws://`, so a renderer that wants to be reachable
from the hosted dashboard needs a real `wss://` **as well**. Both are true at once, hence the list.

The specs already described `endpoints` in the plural; only the code was behind.

## The bound

1 to 4 entries, each a `ws://` or `wss://` URL of at most 255 characters.

ADR-0016 requires bounding without quantifying it. Four, because the `wss://` routinely comes alongside more
than one LAN address: IPv4 and IPv6, two network interfaces, a name and an address, or a local address next to
a public tunnel. The bound protects the size of the row rather than modelling a use case — Adonis cannot probe
a NATed renderer, and has no way of knowing which address it would have been right to keep.

Enforced in two places, because neither covers the other: a CHECK constraint holds the type and the length of
the list, and the validator holds what a CHECK cannot reach (PostgreSQL forbids set-returning functions in a
constraint, so bounding each entry's scheme and length is not expressible there).

## Changes

- Migration altering `endpoint` into `endpoints` (jsonb, nullable), converting any existing row to a
  one-element array, plus `renderers_endpoints_bounded_check`
- `app/constants/renderer.ts`, new: `RENDERER_MAXIMUM_ENDPOINTS`, `RENDERER_ENDPOINT_MAXIMUM_LENGTH`
- `app/validators/renderer.ts`: the `rendererEndpoints()` schema and the `RendererEndpoints` type
- `database/schema_rules.ts` maps the column onto that type, so the regenerated `schema.ts` declares
  `endpoints: RendererEndpoints | null` rather than `any`
- `RendererTransformer` exposes `endpoints`
- `DATA-MODEL.md`, `PROTOCOL-CONTROL.md` and `SELF-HOSTING.md` gain the bound they were missing

No new ADR: ADR-0016 already carries the decision, and the number itself is an implementation detail.

`endpoints` stays an observed field — declared by the renderer, never settable over HTTP — and a renderer that
has never connected keeps `null`.

## Out of scope

Consuming the list. Nothing reads `endpoints` until the control plane (#21) and the bootstrap route (#25);
picking a URL from it belongs to the firmware (#39) and the simulator (#48).

## Verification

`typecheck`, `lint`, `test` (61 passing, 6 of them new on the validator) and `format:check` all pass.

The migration was also exercised against a dev database: the constraint rejects an empty list, five entries and
a jsonb that is not an array; `run` → `rollback` → `run` converts in both directions, the rollback keeping the
first entry since the singular column has nowhere to put the others.